### PR TITLE
[dist] Add Flink 2.3 distribution and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
           - os: 'ubuntu-latest'
             python-version: '3.12'
             flink-version: "2.2"
+          - os: 'ubuntu-latest'
+            python-version: '3.12'
+            flink-version: "2.3"
     steps:
       - uses: actions/checkout@v4
       - name: Install java
@@ -216,6 +219,9 @@ jobs:
           - os: 'ubuntu-latest'
             java-version: "21"
             flink-version: "2.2"
+          - os: 'ubuntu-latest'
+            java-version: "17"
+            flink-version: "2.3"
     steps:
       - uses: actions/checkout@v4
       - name: Install java

--- a/dist/flink-2.3/pom.xml
+++ b/dist/flink-2.3/pom.xml
@@ -25,52 +25,8 @@ under the License.
         <version>0.3-SNAPSHOT</version>
     </parent>
 
-    <artifactId>flink-agents-dist-flink-2.2</artifactId>
-    <name>Flink Agents : Dist : Flink 2.2</name>
-
-    <properties>
-        <flink.version>${flink.2.2.version}</flink.version>
-    </properties>
-
-    <dependencies>
-        <!-- Flink dependencies -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-api-java-bridge</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-python</artifactId>
-            <version>${flink.version}</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
+    <artifactId>flink-agents-dist-flink-2.3</artifactId>
+    <name>Flink Agents : Dist : Flink 2.3</name>
 
     <build>
         <plugins>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -34,6 +34,7 @@ under the License.
         <flink.2.0.version>2.0.2</flink.2.0.version>
         <flink.2.1.version>2.1.3</flink.2.1.version>
         <flink.2.2.version>2.2.1</flink.2.2.version>
+        <flink.2.3.version>2.3.0</flink.2.3.version>
     </properties>
 
     <modules>
@@ -42,6 +43,7 @@ under the License.
         <module>flink-2.0</module>
         <module>flink-2.1</module>
         <module>flink-2.2</module>
+        <module>flink-2.3</module>
     </modules>
 
     <dependencies>

--- a/docs/content/docs/development/memory/long_term_memory.md
+++ b/docs/content/docs/development/memory/long_term_memory.md
@@ -35,7 +35,7 @@ Declare the following resources in your agent plan:
 - An [EmbeddingModel]({{< ref "docs/development/embedding_models" >}}) for vector generation
 - A [VectorStore]({{< ref "docs/development/vector_stores" >}}) for persistent storage
 
-> **Java prerequisite:** Mem0 invokes the chat and embedding models on its own thread executor, which relies on the async-friendly pemja fix. When Mem0 Long-Term Memory is configured together with Java actions, the runtime requires a Flink version of `1.20.5`, `2.0.2`, `2.1.3`, `2.2.1` or higher; otherwise it throws at startup. Either upgrade Flink or use the Python API.
+> **Java prerequisite:** Mem0 invokes the chat and embedding models on its own thread executor, which relies on the async-friendly pemja fix. When Mem0 Long-Term Memory is configured together with Java actions, the runtime requires a Flink version of `1.20.5`, `2.0.2`, `2.1.3`, `2.2.1`, `2.3.0` or higher; otherwise it throws at startup. Either upgrade Flink or use the Python API.
 
 ## Configuration
 

--- a/docs/content/docs/faq/faq.md
+++ b/docs/content/docs/faq/faq.md
@@ -87,7 +87,7 @@ This is important because:
 - **For Java users on JDK 21+**: Async execution is available.
 - **For Java users on JDK < 21**: Async execution is not available and falls back to synchronous execution.
 
-> **Cross-language async note**: Async execution for cross-language resources requires the pemja 0.5.7 fix, available in Flink 1.20.5+ / 2.0.2+ / 2.1.3+ / 2.2.1+. Current builds target Flink 2.2.0, so cross-language calls still run synchronously for now; this is resolved automatically once running on a Flink version that includes the fix.
+> **Cross-language async note**: Async execution for cross-language resources requires the pemja 0.5.7 fix, available in Flink 1.20.5+ / 2.0.2+ / 2.1.3+ / 2.2.1+ / 2.3+. Current builds target Flink 2.3.0, which includes the fix, so cross-language async is enabled by default; on older Flink versions it falls back to synchronous execution automatically.
 
 ### Native Integration Support Matrix
 

--- a/e2e-test/flink-agents-end-to-end-tests-integration/pom.xml
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/pom.xml
@@ -33,9 +33,10 @@ under the License.
         <flink.2.0.version>2.0.2</flink.2.0.version>
         <flink.2.1.version>2.1.3</flink.2.1.version>
         <flink.2.2.version>2.2.1</flink.2.2.version>
+        <flink.2.3.version>2.3.0</flink.2.3.version>
 
-        <flink.version>${flink.2.2.version}</flink.version>
-        <flink.agents.dist.artifactId>flink-agents-dist-flink-2.2</flink.agents.dist.artifactId>
+        <flink.version>${flink.2.3.version}</flink.version>
+        <flink.agents.dist.artifactId>flink-agents-dist-flink-2.3</flink.agents.dist.artifactId>
     </properties>
 
     <dependencies>
@@ -197,6 +198,15 @@ under the License.
             <properties>
                 <flink.version>${flink.2.1.version}</flink.version>
                 <flink.agents.dist.artifactId>flink-agents-dist-flink-2.1</flink.agents.dist.artifactId>
+            </properties>
+        </profile>
+
+        <!-- Flink 2.2 Profile -->
+        <profile>
+            <id>flink-2.2</id>
+            <properties>
+                <flink.version>${flink.2.2.version}</flink.version>
+                <flink.agents.dist.artifactId>flink-agents-dist-flink-2.2</flink.agents.dist.artifactId>
             </properties>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ under the License.
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
         <spotless.version>2.27.1</spotless.version>
         <spotless.skip>false</spotless.skip>
-        <flink.version>2.2.1</flink.version>
+        <flink.version>2.3.0</flink.version>
         <kafka.version>4.0.0</kafka.version>
         <fluss.version>0.9.0-incubating</fluss.version>
         <junit5.version>5.10.1</junit5.version>

--- a/python/_build_backend/tests/test_backend.py
+++ b/python/_build_backend/tests/test_backend.py
@@ -180,6 +180,7 @@ def maven_server(tmp_path_factory) -> tuple[str, Path]:
         ("flink-agents-dist-flink-2.0", "thin"),
         ("flink-agents-dist-flink-2.1", "thin"),
         ("flink-agents-dist-flink-2.2", "thin"),
+        ("flink-agents-dist-flink-2.3", "thin"),
     ]
 
     for artifact_id, classifier in artifacts:
@@ -241,6 +242,12 @@ def test_download_jars_from_local_server(tmp_path, monkeypatch, maven_server) ->
                 "artifact_id": "flink-agents-dist-flink-2.2",
                 "classifier": "thin",
                 "dest": "flink_agents/lib/flink-2.2/",
+                "sha256": expected_sha,
+            },
+            {
+                "artifact_id": "flink-agents-dist-flink-2.3",
+                "classifier": "thin",
+                "dest": "flink_agents/lib/flink-2.3/",
                 "sha256": expected_sha,
             },
         ],

--- a/python/jar_manifest.json
+++ b/python/jar_manifest.json
@@ -31,6 +31,12 @@
       "classifier": "thin",
       "dest": "flink_agents/lib/flink-2.2/",
       "sha256": "PLACEHOLDER"
+    },
+    {
+      "artifact_id": "flink-agents-dist-flink-2.3",
+      "classifier": "thin",
+      "dest": "flink_agents/lib/flink-2.3/",
+      "sha256": "PLACEHOLDER"
     }
   ]
 }

--- a/tools/e2e.sh
+++ b/tools/e2e.sh
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-DEFAULT_FLINK_VERSION="2.2"
+DEFAULT_FLINK_VERSION="2.3"
 
 function run_test {
   local description="$1"

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -43,8 +43,8 @@ Options:
   -e, --e2e         Run e2e tests
   -b, --both        Run both Java and Python tests (default)
   -f, --flink       Specify Flink version to test (can be used multiple times)
-                    Supported versions: 2.2, 1.20
-                    Examples: -f 2.2, -f 1.20, -f 2.2 -f 1.20
+                    Supported versions: 2.3, 2.2, 2.1, 2.0, 1.20
+                    Examples: -f 2.3, -f 1.20, -f 2.3 -f 1.20
                     Default: run all versions if not specified
   -v, --verbose     Show verbose output
   -h, --help        Display this help message


### PR DESCRIPTION
Add Flink 2.3 as a supported distribution while keeping the build baseline at Flink 2.2.1 / Java 11. Flink 2.3 jars are Java 17 bytecode, so 2.3 stays a provided runtime target only — core modules still compile once against the 2.2.1 baseline on JDK 11, mirroring how the MCP module isolates its 17-only dependency.

- dist: new flink-2.3 module with provided deps + thin-jar packaging
- e2e: flink-2.3 profile so IT runs the 2.2.1-built jar on a 2.3 runtime
- ci: add {flink 2.3, java 17} to it-java and it-python matrices
- python: bundle the 2.3 thin jar into the wheel manifest, cover it in the build-backend test, and refresh ut.sh help text

Verified: full build on JDK 11, java IT (27 passed) and python IT (4 passed) on Flink 2.3.

<!--
* Thank you very much for contributing to Flink Agents.
* Please add the relevant components in the PR title. E.g., [api], [runtime], [java], [python], [hotfix], etc.
-->

<!-- Please link the PR to the relevant issue(s). Hotfix doesn't need this. -->
Linked issue: #xxx

### Purpose of change

<!-- What is the purpose of this change? -->

### Tests

<!-- How is this change verified? -->

### API

<!-- Does this change touches any public APIs? -->

### Documentation

<!-- Do not remove this section. Check the proper box only. -->

- [ ] `doc-needed` <!-- Your PR changes impact docs -->
- [ ] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-included` <!-- Your PR already contains the necessary documentation updates -->
