### PR TITLE
Dynamic plan POC (Plan Isolation Version)

### DIFF
--- a/api/src/main/java/org/apache/flink/agents/api/AgentBuilder.java
+++ b/api/src/main/java/org/apache/flink/agents/api/AgentBuilder.java
@@ -43,6 +43,22 @@ public interface AgentBuilder {
     AgentBuilder apply(Agent agent);
 
     /**
+     * Set an agent with a stable deployment name.
+     *
+     * <p>The deployment name identifies the agent operator in the Flink topology and is also used
+     * by clients that update its plan. Implementations that support named deployment override this
+     * method.
+     *
+     * @param agentName Stable name of this deployed agent.
+     * @param agent The agent user defined to run in execution environment.
+     * @return A configured AgentBuilder for method chaining.
+     */
+    default AgentBuilder apply(String agentName, Agent agent) {
+        throw new UnsupportedOperationException(
+                "apply(String, Agent) is not supported by this AgentBuilder.");
+    }
+
+    /**
      * Apply an agent previously registered on the environment (typically via {@code
      * env.loadYaml(...)}) by name.
      *

--- a/dist/flink-1.20/src/main/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtils.java
+++ b/dist/flink-1.20/src/main/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.client;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.shaded.guava31.com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+/** Flink 1.20 bridge from a stable operator uid to its primary OperatorID. */
+final class CoordinationRequestUtils {
+
+    private CoordinationRequestUtils() {}
+
+    static CompletableFuture<CoordinationResponse> send(
+            RestClusterClient<?> restClient,
+            JobID jobId,
+            String operatorUid,
+            CoordinationRequest request) {
+        OperatorID operatorId =
+                new OperatorID(
+                        Hashing.murmur3_128(0)
+                                .hashString(operatorUid, StandardCharsets.UTF_8)
+                                .asBytes());
+        return restClient.sendCoordinationRequest(jobId, operatorId, request);
+    }
+}

--- a/dist/flink-1.20/src/test/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtilsTest.java
+++ b/dist/flink-1.20/src/test/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.client;
+
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateRequest;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CoordinationRequestUtilsTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void convertsUidToPrimaryOperatorIdOnFlinkOneTwenty() {
+        RestClusterClient<String> restClient = mock(RestClusterClient.class);
+        JobID jobId = new JobID();
+        String operatorUid = "flink-agents-coordinated-operator";
+        PlanUpdateRequest request = new PlanUpdateRequest("{}");
+        CompletableFuture<CoordinationResponse> expected = new CompletableFuture<>();
+        when(restClient.sendCoordinationRequest(
+                        eq(jobId), org.mockito.ArgumentMatchers.any(OperatorID.class), eq(request)))
+                .thenReturn(expected);
+
+        CompletableFuture<CoordinationResponse> actual =
+                CoordinationRequestUtils.send(restClient, jobId, operatorUid, request);
+
+        assertThat(actual).isSameAs(expected);
+        ArgumentCaptor<OperatorID> operatorIdCaptor = ArgumentCaptor.forClass(OperatorID.class);
+        verify(restClient)
+                .sendCoordinationRequest(eq(jobId), operatorIdCaptor.capture(), eq(request));
+        assertThat(operatorIdCaptor.getValue().toHexString())
+                .isEqualTo("3be5561e768cf5fc957e8c4b13acd9f9");
+    }
+}

--- a/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/JavaAgentPlanClientE2ETest.java
+++ b/e2e-test/flink-agents-end-to-end-tests-integration/src/test/java/org/apache/flink/agents/integration/test/JavaAgentPlanClientE2ETest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.integration.test;
+
+import org.apache.flink.agents.api.AgentsExecutionEnvironment;
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.EventType;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.api.agents.Agent;
+import org.apache.flink.agents.api.annotation.Action;
+import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.client.AgentPlanClient;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.connector.file.src.FileSource;
+import org.apache.flink.connector.file.src.reader.TextLineInputFormat;
+import org.apache.flink.core.execution.CheckpointType;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Verifies Java client plan activation and name-based routing for chained Agents. */
+public class JavaAgentPlanClientE2ETest {
+
+    private static final String TARGET_AGENT = "target-agent";
+    private static final String CONTROL_AGENT = "control-agent";
+    private static final Set<String> RESULTS = ConcurrentHashMap.newKeySet();
+
+    @Test
+    void updatesChainedAgentsIndependentlyAtCheckpointBoundaries(@TempDir Path tempDir)
+            throws Exception {
+        RESULTS.clear();
+        Path inputDir = Files.createDirectory(tempDir.resolve("input"));
+        Configuration configuration = new Configuration();
+        configuration.set(RestOptions.BIND_PORT, "0");
+        MiniClusterConfiguration miniClusterConfiguration =
+                new MiniClusterConfiguration.Builder()
+                        .setNumTaskManagers(3)
+                        .setNumSlotsPerTaskManager(1)
+                        .setConfiguration(configuration)
+                        .build();
+
+        try (MiniCluster cluster = new MiniCluster(miniClusterConfiguration)) {
+            cluster.start();
+            URI restAddress = cluster.getRestAddress().get();
+            JobGraph jobGraph = createJobGraph(configuration, inputDir);
+            cluster.submitJob(jobGraph).get();
+            JobID jobId = jobGraph.getJobID();
+            waitUntilRunning(cluster, jobId);
+
+            addInputAndWaitFor(inputDir, 1L, "control-v1:target-v1:1");
+
+            try (AgentPlanClient client =
+                    new AgentPlanClient(restAddress.getHost(), restAddress.getPort())) {
+                AgentPlanClient.UpdateResult staged =
+                        client.updateAgentPlan(
+                                jobId, TARGET_AGENT, new AgentPlan(new TargetV2Agent()));
+
+                assertEquals(1L, staged.getPlanVersion());
+                assertEquals(1, staged.getRegisteredSubtasks());
+
+                addInputAndWaitFor(inputDir, 2L, "control-v1:target-v1:2");
+
+                triggerCheckpoint(cluster, jobId);
+                addInputAndWaitFor(inputDir, 3L, "control-v1:target-v1:3");
+
+                AgentPlanClient.UpdateResult staged2 =
+                        client.updateAgentPlan(
+                                jobId, CONTROL_AGENT, new AgentPlan(new ControlV2Agent()));
+
+                assertEquals(1L, staged2.getPlanVersion());
+                assertEquals(1, staged2.getRegisteredSubtasks());
+
+                triggerCheckpoint(cluster, jobId);
+                addInputAndWaitFor(inputDir, 4L, "control-v1:target-v2:4");
+
+                addInputAndWaitFor(inputDir, 5L, "control-v1:target-v2:5");
+
+                triggerCheckpoint(cluster, jobId);
+                addInputAndWaitFor(inputDir, 6L, "control-v2:target-v2:6");
+
+                triggerCheckpoint(cluster, jobId);
+                addInputAndWaitFor(inputDir, 7L, "control-v2:target-v2:7");
+            }
+
+            assertEquals(JobStatus.RUNNING, cluster.getJobStatus(jobId).get(30, TimeUnit.SECONDS));
+            cluster.cancelJob(jobId).get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private static JobGraph createJobGraph(Configuration configuration, Path inputDir) {
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+        env.enableCheckpointing(Duration.ofHours(1).toMillis());
+        env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
+
+        FileSource<String> source =
+                FileSource.forRecordStreamFormat(
+                                new TextLineInputFormat(),
+                                new org.apache.flink.core.fs.Path(inputDir.toUri()))
+                        .monitorContinuously(Duration.ofMillis(50))
+                        .build();
+        org.apache.flink.streaming.api.datastream.DataStream<Long> input =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "gated-input")
+                        .map(Long::valueOf);
+        AgentsExecutionEnvironment agents = AgentsExecutionEnvironment.getExecutionEnvironment(env);
+        DataStream<Object> output1 =
+                agents.fromDataStream(input, value -> value)
+                        .apply(TARGET_AGENT, new TargetV1Agent())
+                        .toDataStream();
+
+        DataStream<String> map = output1.map(Object::toString);
+
+        agents.fromDataStream(map, value -> value)
+                .apply(CONTROL_AGENT, new ControlV1Agent())
+                .toDataStream()
+                .map(new CollectMap())
+                .sinkTo(new DiscardingSink<>());
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    private static void addInputAndWaitFor(Path inputDir, long value, String... expected)
+            throws Exception {
+        Path temporary = inputDir.resolve("." + value + ".tmp");
+        Files.writeString(temporary, Long.toString(value));
+        Path input = inputDir.resolve(value + ".txt");
+        try {
+            Files.move(temporary, input, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException ignored) {
+            Files.move(temporary, input);
+        }
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        while (!RESULTS.containsAll(Set.of(expected)) && System.nanoTime() < deadline) {
+            Thread.sleep(50L);
+        }
+        for (String result : expected) {
+            assertTrue(
+                    RESULTS.contains(result), "Missing result " + result + "; actual=" + RESULTS);
+        }
+    }
+
+    private static void waitUntilRunning(MiniCluster cluster, JobID jobId) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        JobStatus status = cluster.getJobStatus(jobId).get();
+        while (status != JobStatus.RUNNING && System.nanoTime() < deadline) {
+            Thread.sleep(50L);
+            status = cluster.getJobStatus(jobId).get();
+        }
+        assertEquals(JobStatus.RUNNING, status);
+    }
+
+    private static void triggerCheckpoint(MiniCluster cluster, JobID jobId) throws Exception {
+        cluster.triggerCheckpoint(jobId, CheckpointType.CONFIGURED).get(30, TimeUnit.SECONDS);
+    }
+
+    public static final class TargetV1Agent extends Agent {
+        @Action(EventType.InputEvent)
+        public static void onInput(Event event, RunnerContext context) {
+            emit("target-v1", event, context);
+        }
+    }
+
+    public static final class TargetV2Agent extends Agent {
+        @Action(EventType.InputEvent)
+        public static void onInput(Event event, RunnerContext context) {
+            emit("target-v2", event, context);
+        }
+    }
+
+    public static final class ControlV1Agent extends Agent {
+        @Action(EventType.InputEvent)
+        public static void onInput(Event event, RunnerContext context) {
+            emit("control-v1", event, context);
+        }
+    }
+
+    public static final class ControlV2Agent extends Agent {
+        @Action(EventType.InputEvent)
+        public static void onInput(Event event, RunnerContext context) {
+            emit("control-v2", event, context);
+        }
+    }
+
+    private static void emit(String prefix, Event event, RunnerContext context) {
+        context.sendEvent(new OutputEvent(prefix + ":" + InputEvent.fromEvent(event).getInput()));
+    }
+
+    private static final class CollectMap implements MapFunction<Object, Object> {
+        @Override
+        public Object map(Object value) {
+            RESULTS.add(value.toString());
+            return value;
+        }
+    }
+}

--- a/plan/src/main/java/org/apache/flink/agents/plan/PythonFunction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/PythonFunction.java
@@ -23,12 +23,13 @@ import java.util.Objects;
 
 /** Represent a Python function. */
 public class PythonFunction implements Function {
-    private static final String CALL_PYTHON_FUNCTION = "function.call_python_function";
+    private static final String CALL_PYTHON_FUNCTION = "call_python_function";
 
     private final String module;
     private final String qualName;
 
     private transient PythonInterpreter interpreter;
+    private transient String invocationModule;
 
     public PythonFunction(String module, String qualName) {
         this.module = module;
@@ -37,6 +38,10 @@ public class PythonFunction implements Function {
 
     public void setInterpreter(PythonInterpreter interpreter) {
         this.interpreter = interpreter;
+    }
+
+    public void setInvocationModule(String invocationModule) {
+        this.invocationModule = invocationModule;
     }
 
     @Override
@@ -48,7 +53,14 @@ public class PythonFunction implements Function {
                             + "invocation.");
         }
 
-        return interpreter.invoke(CALL_PYTHON_FUNCTION, module, qualName, args);
+        if (invocationModule == null) {
+            throw new IllegalStateException(
+                    "PythonFunction requires the Python invocation module; not set on this "
+                            + "descriptor. The runtime injects it before invocation.");
+        }
+
+        return interpreter.invokeMethod(
+                invocationModule, CALL_PYTHON_FUNCTION, module, qualName, args);
     }
 
     @Override

--- a/plan/src/main/java/org/apache/flink/agents/plan/PythonFunction.java
+++ b/plan/src/main/java/org/apache/flink/agents/plan/PythonFunction.java
@@ -30,6 +30,7 @@ public class PythonFunction implements Function {
 
     private transient PythonInterpreter interpreter;
     private transient String invocationModule;
+    private transient String moduleNamespace;
 
     public PythonFunction(String module, String qualName) {
         this.module = module;
@@ -42,6 +43,10 @@ public class PythonFunction implements Function {
 
     public void setInvocationModule(String invocationModule) {
         this.invocationModule = invocationModule;
+    }
+
+    public void setModuleNamespace(String moduleNamespace) {
+        this.moduleNamespace = moduleNamespace;
     }
 
     @Override
@@ -59,8 +64,12 @@ public class PythonFunction implements Function {
                             + "descriptor. The runtime injects it before invocation.");
         }
 
+        if (moduleNamespace == null) {
+            return interpreter.invokeMethod(
+                    invocationModule, CALL_PYTHON_FUNCTION, module, qualName, args);
+        }
         return interpreter.invokeMethod(
-                invocationModule, CALL_PYTHON_FUNCTION, module, qualName, args);
+                invocationModule, CALL_PYTHON_FUNCTION, module, qualName, args, moduleNamespace);
     }
 
     @Override

--- a/plan/src/test/java/org/apache/flink/agents/plan/PlanFunctionDispatchTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/PlanFunctionDispatchTest.java
@@ -82,6 +82,26 @@ class PlanFunctionDispatchTest {
     }
 
     @Test
+    void pythonFunctionDispatchIncludesPlanModuleNamespaceWhenConfigured() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonFunction fn = new PythonFunction("app.agent", "handle");
+        fn.setInterpreter(interpreter);
+        fn.setInvocationModule("__fa_function_module");
+        fn.setModuleNamespace("__fa_job_operator_v2");
+
+        fn.call("event");
+
+        verify(interpreter)
+                .invokeMethod(
+                        "__fa_function_module",
+                        "call_python_function",
+                        "app.agent",
+                        "handle",
+                        new Object[] {"event"},
+                        "__fa_job_operator_v2");
+    }
+
+    @Test
     void pythonFunctionCheckSignatureIsLazyNoOpForAnyArity() throws Exception {
         PythonFunction fn = new PythonFunction("test.module", "test_handler");
 

--- a/plan/src/test/java/org/apache/flink/agents/plan/PlanFunctionDispatchTest.java
+++ b/plan/src/test/java/org/apache/flink/agents/plan/PlanFunctionDispatchTest.java
@@ -22,11 +22,14 @@ import org.apache.flink.agents.api.Event;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.junit.jupiter.api.Test;
+import pemja.core.PythonInterpreter;
 
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /** Dispatch tests for plan-layer {@link Function} invocation. */
 class PlanFunctionDispatchTest {
@@ -58,6 +61,24 @@ class PlanFunctionDispatchTest {
         assertThatThrownBy(() -> fn.call(new InputEvent(new HashMap<>()), null))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("PythonFunction requires the Python interpreter");
+    }
+
+    @Test
+    void pythonFunctionDispatchUsesBoundModuleMethod() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonFunction fn = new PythonFunction("test.module", "test_handler");
+        fn.setInterpreter(interpreter);
+        fn.setInvocationModule("__fa_function_module");
+
+        fn.call("event");
+
+        verify(interpreter)
+                .invokeMethod(
+                        "__fa_function_module",
+                        "call_python_function",
+                        "test.module",
+                        "test_handler",
+                        new Object[] {"event"});
     }
 
     @Test

--- a/python/flink_agents/api/_java_utils.py
+++ b/python/flink_agents/api/_java_utils.py
@@ -1,0 +1,62 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from importlib_resources import files
+from importlib_resources.abc import Traversable
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.util.java_utils import add_jars_to_context_class_loader
+
+from flink_agents.api.version_compatibility import flink_version_manager
+
+
+def add_flink_agents_jars(env: StreamExecutionEnvironment) -> None:
+    """Add the common and version-specific Flink Agents JARs to a job."""
+    for jar_url in _flink_agents_jar_urls():
+        env.add_jars(jar_url)
+
+
+def add_flink_agents_jars_to_context_class_loader() -> None:
+    """Make Flink Agents Java APIs visible to the current PyFlink gateway."""
+    add_jars_to_context_class_loader(_flink_agents_jar_urls())
+
+
+def _flink_agents_jar_urls() -> list[str]:
+    major_version = flink_version_manager.major_version
+    if not major_version:
+        msg = "Apache Flink is not installed."
+        raise ModuleNotFoundError(msg)
+
+    lib_base = files("flink_agents.lib")
+    return _jar_urls(lib_base / "common", "Flink Agents common JAR not found.") + (
+        _jar_urls(
+            lib_base / f"flink-{major_version}",
+            f"Flink Agents dist JAR for Flink {major_version} not found.",
+        )
+    )
+
+
+def _jar_urls(directory: Traversable, missing_message: str) -> list[str]:
+    if not directory.is_dir():
+        raise FileNotFoundError(missing_message)
+    jar_urls = sorted(
+        f"file://{jar_file}"
+        for jar_file in directory.iterdir()
+        if jar_file.is_file() and str(jar_file).endswith(".jar")
+    )
+    if not jar_urls:
+        raise FileNotFoundError(missing_message)
+    return jar_urls

--- a/python/flink_agents/api/agent_plan_client.py
+++ b/python/flink_agents/api/agent_plan_client.py
@@ -1,0 +1,107 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import importlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Mapping, Type
+
+from typing_extensions import Self
+
+from flink_agents.api._java_utils import (
+    add_flink_agents_jars_to_context_class_loader,
+)
+
+if TYPE_CHECKING:
+    from flink_agents.api.agents.agent import Agent
+
+
+@dataclass(frozen=True)
+class PlanUpdateResult:
+    """Confirmation that the current JobManager attempt accepted an AgentPlan.
+
+    ``registered_subtasks`` is the number of subtask gateways registered when
+    the request was accepted as a volatile candidate. It does not mean the plan
+    was announced, made durable, or became effective.
+    """
+
+    plan_version: int
+    plan_id: str
+    registered_subtasks: int
+
+
+class AgentPlanClient(ABC):
+    """Client for submitting AgentPlan updates to a running Flink job."""
+
+    @staticmethod
+    def create(rest_address: str, rest_port: int) -> "AgentPlanClient":
+        """Create a client for a Flink JobManager REST endpoint.
+
+        Args:
+            rest_address: JobManager hostname or IP address, without a URL scheme
+                or path.
+            rest_port: JobManager REST port in the range 1 through 65535.
+
+        Raises:
+            ValueError: If the address is blank or the port is outside the valid
+                range.
+        """
+        if not rest_address or not rest_address.strip():
+            msg = "The REST address must not be blank."
+            raise ValueError(msg)
+        if rest_port <= 0 or rest_port > 65535:
+            msg = "The REST port must be between 1 and 65535."
+            raise ValueError(msg)
+        add_flink_agents_jars_to_context_class_loader()
+        runtime_module = importlib.import_module(
+            "flink_agents.runtime.agent_plan_client"
+        )
+        return runtime_module.create_instance(rest_address, rest_port)
+
+    @abstractmethod
+    def update_agent_plan(
+        self, job_id: str, agent_name: str, agent_plan_json: str
+    ) -> PlanUpdateResult:
+        """Validate and submit a complete AgentPlan JSON document."""
+
+    @abstractmethod
+    def update_agent(
+        self,
+        job_id: str,
+        agent: "Agent",
+        name: str | None = None,
+        config: Mapping[str, Any] | None = None,
+    ) -> PlanUpdateResult:
+        """Compile an Agent with optional config data and submit it."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the underlying REST client."""
+
+    def __enter__(self) -> Self:
+        """Return this client for use as a context manager."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close this client when leaving a context manager."""
+        self.close()

--- a/python/flink_agents/api/execution_environment.py
+++ b/python/flink_agents/api/execution_environment.py
@@ -22,11 +22,11 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List
 if TYPE_CHECKING:
     from pathlib import Path
 
-from importlib_resources import files
 from pyflink.common import TypeInformation
 from pyflink.datastream import DataStream, KeySelector, StreamExecutionEnvironment
 from pyflink.table import Schema, StreamTableEnvironment, Table
 
+from flink_agents.api._java_utils import add_flink_agents_jars
 from flink_agents.api.agents.agent import Agent
 from flink_agents.api.configuration import Configuration
 from flink_agents.api.resource import (
@@ -34,7 +34,6 @@ from flink_agents.api.resource import (
     ResourceType,
     SerializableResource,
 )
-from flink_agents.api.version_compatibility import flink_version_manager
 
 
 class AgentBuilder(ABC):
@@ -130,35 +129,7 @@ class AgentsExecutionEnvironment(ABC):
             err_msg = "A StreamExecutionEnvironment is required."
             raise ValueError(err_msg)
 
-        major_version = flink_version_manager.major_version
-        if not major_version:
-            err_msg = "Apache Flink is not installed."
-            raise ModuleNotFoundError(err_msg)
-
-        lib_base = files("flink_agents.lib")
-
-        # Load the common JAR (shared dependencies)
-        common_lib = lib_base / "common"
-        if common_lib.is_dir():
-            for jar_file in common_lib.iterdir():
-                if jar_file.is_file() and str(jar_file).endswith(".jar"):
-                    env.add_jars(f"file://{jar_file}")
-        else:
-            err_msg = "Flink Agents common JAR not found."
-            raise FileNotFoundError(err_msg)
-
-        # Load the version-specific thin JAR
-        version_dir = f"flink-{major_version}"
-        version_lib = lib_base / version_dir
-
-        # Check if version-specific directory exists
-        if version_lib.is_dir():
-            for jar_file in version_lib.iterdir():
-                if jar_file.is_file() and str(jar_file).endswith(".jar"):
-                    env.add_jars(f"file://{jar_file}")
-        else:
-            err_msg = f"Flink Agents dist JAR for Flink {major_version} not found."
-            raise FileNotFoundError(err_msg)
+        add_flink_agents_jars(env)
 
         return importlib.import_module(
             "flink_agents.runtime.remote_execution_environment"

--- a/python/flink_agents/api/execution_environment.py
+++ b/python/flink_agents/api/execution_environment.py
@@ -41,7 +41,9 @@ class AgentBuilder(ABC):
     """Builder for integrating agent with input and output."""
 
     @abstractmethod
-    def apply(self, agent: "Agent | str") -> "AgentBuilder":
+    def apply(
+        self, agent: "Agent | str", name: str | None = None
+    ) -> "AgentBuilder":
         """Set agent of AgentBuilder.
 
         Parameters
@@ -49,6 +51,9 @@ class AgentBuilder(ABC):
         agent : Agent | str
             Either an Agent instance, or the name of an agent registered
             on the environment (e.g. by ``load_yaml``).
+        name : str, optional
+            Stable deployment name. Defaults to the Agent class name, or to
+            the registry name when ``agent`` is a string.
         """
 
     @abstractmethod

--- a/python/flink_agents/api/tests/test_java_utils.py
+++ b/python/flink_agents/api/tests/test_java_utils.py
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from pathlib import Path
+
+import pytest
+
+from flink_agents.api._java_utils import _jar_urls
+
+
+def test_jar_urls_rejects_empty_directory(tmp_path: Path) -> None:
+    """An empty generated lib directory must not defer failure to Py4J."""
+    with pytest.raises(FileNotFoundError, match="missing test JAR"):
+        _jar_urls(tmp_path, "missing test JAR")

--- a/python/flink_agents/e2e_tests/e2e_tests_integration/agent_plan_client_test.py
+++ b/python/flink_agents/e2e_tests/e2e_tests_integration/agent_plan_client_test.py
@@ -1,0 +1,262 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+import time
+from contextlib import suppress
+from pathlib import Path
+
+from pyflink.common import Configuration, Duration, JobStatus, WatermarkStrategy
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import RuntimeExecutionMode, StreamExecutionEnvironment
+from pyflink.datastream.connectors.file_system import FileSource, StreamFormat
+from pyflink.java_gateway import get_gateway
+
+from flink_agents.api.agent_plan_client import AgentPlanClient
+from flink_agents.api.agents.agent import Agent
+from flink_agents.api.decorators import action
+from flink_agents.api.events.event import Event, InputEvent, OutputEvent
+from flink_agents.api.execution_environment import AgentsExecutionEnvironment
+from flink_agents.api.runner_context import RunnerContext
+
+_AGENT_NAME = "review-agent"
+
+
+class V1Agent(Agent):
+    """Initial plan used by the running job."""
+
+    @action(InputEvent.EVENT_TYPE)
+    @staticmethod
+    def on_input(event: Event, context: RunnerContext) -> None:
+        value = InputEvent.from_event(event).input
+        context.send_event(OutputEvent(output=f"v1:{value}"))
+
+
+class V2Agent(Agent):
+    """Replacement plan submitted through the Python client."""
+
+    @action(InputEvent.EVENT_TYPE)
+    @staticmethod
+    def on_input(event: Event, context: RunnerContext) -> None:
+        value = InputEvent.from_event(event).input
+        context.send_event(OutputEvent(output=f"v2:{value}"))
+
+
+class _AppendToFile:
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def __call__(self, value: str) -> str:
+        with self._path.open("a", encoding="utf-8") as output:
+            output.write(f"{value}\n")
+        return value
+
+
+def test_python_client_updates_running_job_at_second_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """Start a real job and switch its Python AgentPlan through JM REST."""
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    result_file = tmp_path / "results.txt"
+    _add_input(input_dir, 1)
+
+    configuration = Configuration()
+    configuration.set_string("rest.bind-port", "0")
+    configuration.set_integer("taskmanager.numberOfTaskSlots", 1)
+    configuration.set_string("restart-strategy.type", "disable")
+    configuration.set_integer("python.fn-execution.bundle.size", 1)
+
+    gateway = get_gateway()
+    cluster = _start_mini_cluster(gateway, configuration)
+    job_client = None
+    try:
+        rest_uri = cluster.getRestAddress().get(
+            30,
+            gateway.jvm.java.util.concurrent.TimeUnit.SECONDS,
+        )
+        rest_address = str(rest_uri.getHost())
+        rest_port = int(rest_uri.getPort())
+        env = _create_remote_environment(
+            gateway,
+            configuration,
+            rest_address,
+            rest_port,
+        )
+        _build_job(env, input_dir, result_file)
+        job_client = env.execute_async("python-agent-plan-client-e2e")
+        _wait_until_running(job_client)
+        job_id = str(job_client.get_job_id())
+
+        _wait_for_lines(job_client, result_file, ["v1:1"])
+
+        with AgentPlanClient.create(rest_address, rest_port) as client:
+            staged = client.update_agent(job_id, V2Agent(), name=_AGENT_NAME)
+            assert staged.plan_version == 1
+            assert staged.registered_subtasks == 1
+
+        _add_input(input_dir, 2)
+        _wait_for_lines(job_client, result_file, ["v1:1", "v1:2"])
+
+        _trigger_checkpoint(gateway, cluster, job_id)
+        _add_input(input_dir, 3)
+        _wait_for_lines(job_client, result_file, ["v1:1", "v1:2", "v1:3"])
+
+        _trigger_checkpoint(gateway, cluster, job_id)
+        _add_input(input_dir, 4)
+        _wait_for_lines(job_client, result_file, ["v1:1", "v1:2", "v1:3", "v2:4"])
+
+        assert _read_lines(result_file) == ["v1:1", "v1:2", "v1:3", "v2:4"]
+        _assert_running(job_client)
+    finally:
+        with suppress(Exception):
+            if (
+                job_client is not None
+                and not job_client.get_job_status().result().is_terminal_state()
+            ):
+                job_client.cancel().result(timeout=30)
+        cluster.closeAsync().get(
+            30,
+            gateway.jvm.java.util.concurrent.TimeUnit.SECONDS,
+        )
+
+
+def _start_mini_cluster(gateway: object, configuration: Configuration) -> object:
+    cluster_configuration = (
+        gateway.jvm.org.apache.flink.runtime.minicluster.MiniClusterConfiguration.Builder()
+        .setConfiguration(configuration._j_configuration)
+        .setNumTaskManagers(2)
+        .setNumSlotsPerTaskManager(1)
+        .withRandomPorts()
+        .build()
+    )
+    cluster = gateway.jvm.org.apache.flink.runtime.minicluster.MiniCluster(
+        cluster_configuration
+    )
+    cluster.start()
+    return cluster
+
+
+def _create_remote_environment(
+    gateway: object,
+    configuration: Configuration,
+    rest_address: str,
+    rest_port: int,
+) -> StreamExecutionEnvironment:
+    empty_jars = gateway.new_array(gateway.jvm.java.lang.String, 0)
+    java_env = gateway.jvm.org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.createRemoteEnvironment(
+        rest_address,
+        rest_port,
+        configuration._j_configuration,
+        empty_jars,
+    )
+    return StreamExecutionEnvironment(java_env)
+
+
+def _build_job(
+    env: StreamExecutionEnvironment,
+    input_dir: Path,
+    result_file: Path,
+) -> None:
+    env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+    env.set_parallelism(1)
+    env.enable_checkpointing(86_400_000)
+    env.get_checkpoint_config().set_max_concurrent_checkpoints(1)
+
+    source = (
+        FileSource.for_record_stream_format(
+            StreamFormat.text_line_format(), input_dir.as_uri()
+        )
+        .monitor_continuously(Duration.of_millis(100))
+        .build()
+    )
+    input_stream = env.from_source(
+        source,
+        WatermarkStrategy.no_watermarks(),
+        "agent-plan-update-input",
+    )
+    python_input = input_stream.map(lambda value: value)
+    agents = AgentsExecutionEnvironment.get_execution_environment(env=env)
+    output_stream = (
+        agents.from_datastream(python_input, key_selector=lambda value: value)
+        .apply(V1Agent(), name=_AGENT_NAME)
+        .to_datastream(output_type=Types.STRING())
+    )
+    output_stream.map(_AppendToFile(result_file), output_type=Types.STRING()).print()
+
+
+def _add_input(input_dir: Path, value: int) -> None:
+    temporary = input_dir / f".{value}.tmp"
+    temporary.write_text(str(value), encoding="utf-8")
+    temporary.replace(input_dir / f"{value}.txt")
+
+
+def _wait_until_running(job_client: object) -> None:
+    deadline = time.monotonic() + 30
+    status = job_client.get_job_status().result()
+    while status != JobStatus.RUNNING and time.monotonic() < deadline:
+        time.sleep(0.05)
+        try:
+            status = job_client.get_job_status().result()
+        except Exception as error:
+            result = job_client.get_job_execution_result().result()
+            message = f"MiniCluster stopped before the job reached RUNNING: {result!r}"
+            raise AssertionError(message) from error
+    assert status == JobStatus.RUNNING
+
+
+def _assert_running(job_client: object) -> None:
+    status = job_client.get_job_status().result()
+    if status.is_terminal_state():
+        job_client.get_job_execution_result().result()
+    assert status == JobStatus.RUNNING
+
+
+def _wait_for_lines(job_client: object, result_file: Path, expected: list[str]) -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if _read_lines(result_file) == expected:
+            return
+        try:
+            status = job_client.get_job_status().result()
+        except Exception as error:
+            result = job_client.get_job_execution_result().result()
+            message = f"MiniCluster stopped before producing {expected!r}: {result!r}"
+            raise AssertionError(message) from error
+        if status.is_terminal_state():
+            job_client.get_job_execution_result().result()
+            message = f"Job reached {status.name} before producing {expected!r}."
+            raise AssertionError(message)
+        time.sleep(0.05)
+    message = f"Timed out waiting for {expected!r}; actual={_read_lines(result_file)!r}"
+    raise AssertionError(message)
+
+
+def _read_lines(result_file: Path) -> list[str]:
+    if not result_file.exists():
+        return []
+    return result_file.read_text(encoding="utf-8").splitlines()
+
+
+def _trigger_checkpoint(gateway: object, cluster: object, job_id: str) -> None:
+    java_job_id = gateway.jvm.org.apache.flink.api.common.JobID.fromHexString(job_id)
+    checkpoint_type = (
+        gateway.jvm.org.apache.flink.core.execution.CheckpointType.CONFIGURED
+    )
+    cluster.triggerCheckpoint(java_job_id, checkpoint_type).get(
+        30,
+        gateway.jvm.java.util.concurrent.TimeUnit.SECONDS,
+    )

--- a/python/flink_agents/plan/actions/action.py
+++ b/python/flink_agents/plan/actions/action.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, field_serializer, model_validator
 
 from flink_agents.api.events.event import Event
 from flink_agents.api.runner_context import RunnerContext
+from flink_agents.plan import module_namespace
 from flink_agents.plan.function import Function, JavaFunction, PythonFunction
 
 _CONFIG_TYPE = "__config_type__"
@@ -96,7 +97,9 @@ class Action(BaseModel):
             return self
         for name, value in config.items():
             try:
-                module = importlib.import_module(value[0])
+                module = importlib.import_module(
+                    module_namespace.qualify(module_namespace.current(), value[0])
+                )
                 clazz = getattr(module, value[1])
                 self["config"][name] = clazz.model_validate(value[2])
             except Exception:  # noqa : PERF203

--- a/python/flink_agents/plan/function.py
+++ b/python/flink_agents/plan/function.py
@@ -314,7 +314,15 @@ class JavaFunction(Function):
             raise TypeError(msg)
 
 
-def call_python_function(module: str, qualname: str, func_args: Tuple[Any, ...]) -> Any:
+def resolve_python_function(module: str, qualname: str) -> None:
+    """Import and resolve one declared action without executing it."""
+    python_func = PythonFunction(module=module, qualname=qualname)
+    python_func.as_callable()
+
+
+def call_python_function(
+    module: str, qualname: str, func_args: Tuple[Any, ...]
+) -> Any:
     """Used to call a Python function in the Pemja environment.
 
     Uses selective caching to reuse PythonFunction instances for identical

--- a/python/flink_agents/plan/function.py
+++ b/python/flink_agents/plan/function.py
@@ -20,10 +20,12 @@ import importlib
 import inspect
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Tuple, get_type_hints
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Iterable, List, Tuple, get_type_hints
 
 from pydantic import BaseModel, PrivateAttr, model_serializer
 
+from flink_agents.plan import module_namespace
 from flink_agents.plan.utils import check_type_match
 
 # Global cache for PythonFunction instances to avoid repeated creation
@@ -33,6 +35,28 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def bind_python_module_namespace(namespace: str | None) -> Iterable[None]:
+    """Bind the namespace used by plan descriptors created in this context."""
+    with module_namespace.bind(namespace):
+        yield
+
+
+def acquire_python_module_namespace(namespace: str, artifact_path: str) -> None:
+    """Acquire a runtime lease for one plan-version module namespace."""
+    module_namespace.acquire(namespace, artifact_path)
+
+
+def release_python_module_namespace(namespace: str) -> bool:
+    """Release a runtime lease and drop the namespace after the last user."""
+    dropped = module_namespace.release(namespace, drop_if_unused=True)
+    if dropped:
+        for cache_key in list(_PYTHON_FUNCTION_CACHE):
+            if cache_key[0].startswith(namespace + "."):
+                del _PYTHON_FUNCTION_CACHE[cache_key]
+    return dropped
 
 
 def _is_function_cacheable(func: Callable) -> bool:
@@ -133,6 +157,9 @@ class PythonFunction(Function):
     qualname: str
     __func: Callable = None
     __is_cacheable: bool = None
+    _module_namespace: str | None = PrivateAttr(
+        default_factory=module_namespace.current
+    )
 
     @model_serializer
     def __custom_serializer(self) -> dict[str, Any]:
@@ -222,7 +249,9 @@ class PythonFunction(Function):
 
     def __get_func(self) -> Callable:
         if self.__func is None:
-            module = importlib.import_module(self.module)
+            module = importlib.import_module(
+                module_namespace.qualify(self._module_namespace, self.module)
+            )
             # TODO: support function of inner class.
             if "." in self.qualname:
                 # Handle class methods (e.g., 'ClassName.method')
@@ -233,6 +262,10 @@ class PythonFunction(Function):
                 # Handle standalone functions
                 self.__func = getattr(module, self.qualname)
         return self.__func
+
+    def set_module_namespace(self, namespace: str | None) -> None:
+        """Bind this descriptor to one plan-version module namespace."""
+        self._module_namespace = namespace
 
     def is_cacheable(self) -> bool:
         """Check if this function is cacheable, caching the result for future calls."""
@@ -314,19 +347,27 @@ class JavaFunction(Function):
             raise TypeError(msg)
 
 
-def resolve_python_function(module: str, qualname: str) -> None:
+def resolve_python_function(
+    module: str, qualname: str, namespace: str | None = None
+) -> None:
     """Import and resolve one declared action without executing it."""
     python_func = PythonFunction(module=module, qualname=qualname)
+    python_func.set_module_namespace(namespace)
     python_func.as_callable()
 
 
 def call_python_function(
-    module: str, qualname: str, func_args: Tuple[Any, ...]
+    module: str,
+    qualname: str,
+    func_args: Tuple[Any, ...],
+    namespace: str | None = None,
 ) -> Any:
     """Used to call a Python function in the Pemja environment.
 
     Uses selective caching to reuse PythonFunction instances for identical
     (module, qualname) pairs to improve performance during frequent invocations.
+    Artifact switching clears this cache at the checkpoint barrier before the
+    new plan resolves any action.
     Only caches functions that are safe to cache (no closures, generators, etc.).
 
     Parameters
@@ -343,18 +384,21 @@ def call_python_function(
     Any
         The result of calling the function with the provided arguments.
     """
-    cache_key = (module, qualname)
+    resolved_module = module_namespace.qualify(namespace, module)
+    cache_key = (resolved_module, qualname)
 
     python_func = None
 
     if cache_key not in _PYTHON_FUNCTION_CACHE:
         python_func = PythonFunction(module=module, qualname=qualname)
+        python_func.set_module_namespace(namespace)
         if python_func.is_cacheable():
             _PYTHON_FUNCTION_CACHE[cache_key] = python_func
     else:
         python_func = _PYTHON_FUNCTION_CACHE[cache_key]
 
-    func_result = python_func(*func_args)
+    with bind_python_module_namespace(namespace):
+        func_result = python_func(*func_args)
     return func_result
 
 

--- a/python/flink_agents/plan/module_namespace.py
+++ b/python/flink_agents/plan/module_namespace.py
@@ -1,0 +1,238 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import builtins
+import importlib.abc
+import importlib.util
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from importlib.machinery import ModuleSpec, PathFinder
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
+
+_ARTIFACT_PATH_ATTRIBUTE = "__flink_agents_artifact_path__"
+_FINDER_MARKER = "__flink_agents_module_namespace_finder__"
+_FRAMEWORK_PACKAGE = "flink_agents"
+_NAMESPACE_USERS: dict[str, int] = {}
+_NAMESPACE_LOCK = threading.RLock()
+_ORIGINAL_IMPORT = builtins.__import__
+_CURRENT_NAMESPACE: ContextVar[str | None] = ContextVar(
+    "flink_agents_plan_module_namespace", default=None
+)
+
+
+@contextmanager
+def bind(namespace: str | None) -> Iterator[None]:
+    """Bind the plan namespace used while runtime objects are constructed."""
+    token = _CURRENT_NAMESPACE.set(namespace)
+    try:
+        yield
+    finally:
+        _CURRENT_NAMESPACE.reset(token)
+
+
+def current() -> str | None:
+    """Return the namespace bound to the current execution context."""
+    return _CURRENT_NAMESPACE.get()
+
+
+def register(namespace: str, artifact_path: str | Path) -> ModuleType:
+    """Register an artifact as a synthetic package root."""
+    if not namespace.isidentifier():
+        msg = f"Invalid Python module namespace: {namespace!r}"
+        raise ValueError(msg)
+
+    with _NAMESPACE_LOCK:
+        normalized_path = os.path.realpath(os.fspath(artifact_path))
+        if not Path(normalized_path).exists():
+            msg = f"Python artifact path does not exist: {normalized_path}"
+            raise ValueError(msg)
+
+        existing = sys.modules.get(namespace)
+        if existing is not None:
+            registered_path = existing.__dict__.get(_ARTIFACT_PATH_ATTRIBUTE)
+            if registered_path != normalized_path:
+                msg = (
+                    f"Python module namespace {namespace!r} is already registered "
+                    f"for {registered_path!r}, not {normalized_path!r}"
+                )
+                raise ValueError(msg)
+            return existing
+
+        package = ModuleType(namespace)
+        package.__package__ = namespace
+        package.__path__ = [normalized_path]
+        setattr(package, _ARTIFACT_PATH_ATTRIBUTE, normalized_path)
+        spec = ModuleSpec(namespace, loader=None, is_package=True)
+        spec.submodule_search_locations = [normalized_path]
+        package.__spec__ = spec
+        sys.modules[namespace] = package
+        return package
+
+
+def acquire(namespace: str, artifact_path: str | Path) -> ModuleType:
+    """Acquire one runtime lease on a shared namespace package."""
+    with _NAMESPACE_LOCK:
+        if _NAMESPACE_USERS.get(namespace, 0) == 0 and _is_loaded(namespace):
+            drop(namespace)
+        package = register(namespace, artifact_path)
+        _NAMESPACE_USERS[namespace] = _NAMESPACE_USERS.get(namespace, 0) + 1
+        return package
+
+
+def release(namespace: str, drop_if_unused: bool = False) -> bool:  # noqa: FBT001
+    """Release one runtime lease and optionally drop an unused namespace."""
+    with _NAMESPACE_LOCK:
+        users = _NAMESPACE_USERS.get(namespace, 0)
+        if users <= 0:
+            msg = f"Python module namespace {namespace!r} has no runtime lease"
+            raise ValueError(msg)
+
+        users -= 1
+        if users > 0:
+            _NAMESPACE_USERS[namespace] = users
+            return False
+
+        del _NAMESPACE_USERS[namespace]
+        if drop_if_unused:
+            drop(namespace)
+            return True
+        return False
+
+
+def qualify(namespace: str | None, logical_module: str) -> str:
+    """Map an artifact-owned logical module into a plan namespace."""
+    if namespace is None:
+        return logical_module
+    if logical_module == namespace or logical_module.startswith(namespace + "."):
+        return logical_module
+    if logical_module == _FRAMEWORK_PACKAGE or logical_module.startswith(
+        _FRAMEWORK_PACKAGE + "."
+    ):
+        return logical_module
+
+    top_level_module = logical_module.split(".", 1)[0]
+    try:
+        artifact_spec = importlib.util.find_spec(f"{namespace}.{top_level_module}")
+    except (ModuleNotFoundError, ValueError):
+        artifact_spec = None
+    if artifact_spec is None:
+        return logical_module
+    return f"{namespace}.{logical_module}"
+
+
+def drop(namespace: str) -> None:
+    """Force-remove exactly one synthetic namespace tree from ``sys.modules``."""
+    with _NAMESPACE_LOCK:
+        _NAMESPACE_USERS.pop(namespace, None)
+        for loaded_name in list(sys.modules):
+            if loaded_name == namespace or loaded_name.startswith(namespace + "."):
+                del sys.modules[loaded_name]
+
+
+def usage_count(namespace: str) -> int:
+    """Return the number of runtimes currently leasing ``namespace``."""
+    with _NAMESPACE_LOCK:
+        return _NAMESPACE_USERS.get(namespace, 0)
+
+
+def _is_loaded(namespace: str) -> bool:
+    return any(
+        name == namespace or name.startswith(namespace + ".") for name in sys.modules
+    )
+
+
+def _private_builtins(namespace: str) -> dict[str, Any]:
+    module_builtins = dict(vars(builtins))
+
+    def namespace_import(
+        name: str,
+        globals: dict[str, Any] | None = None,
+        locals: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> ModuleType:
+        resolved_name = qualify(namespace, name) if level == 0 else name
+        imported = _ORIGINAL_IMPORT(resolved_name, globals, locals, fromlist, level)
+        if level == 0 and resolved_name != name and not fromlist:
+            top_level_module = name.split(".", 1)[0]
+            return sys.modules[f"{namespace}.{top_level_module}"]
+        return imported
+
+    module_builtins["__import__"] = namespace_import
+    return module_builtins
+
+
+class _NamespaceLoader(importlib.abc.Loader):
+    def __init__(self, delegate: Any, namespace: str) -> None:
+        self._delegate = delegate
+        self._namespace = namespace
+
+    def create_module(self, spec: ModuleSpec) -> ModuleType | None:
+        create_module = getattr(self._delegate, "create_module", None)
+        return create_module(spec) if create_module is not None else None
+
+    def exec_module(self, module: ModuleType) -> None:
+        module.__dict__["__builtins__"] = _private_builtins(self._namespace)
+        exec_module = getattr(self._delegate, "exec_module", None)
+        if exec_module is None:
+            msg = f"Loader for {module.__name__!r} cannot execute modules"
+            raise ImportError(msg)
+        exec_module(module)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._delegate, name)
+
+
+class _NamespaceFinder(importlib.abc.MetaPathFinder):
+    def __init__(self) -> None:
+        setattr(self, _FINDER_MARKER, True)
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: list[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
+        namespace, separator, _ = fullname.partition(".")
+        if not separator:
+            return None
+        package = sys.modules.get(namespace)
+        if (
+            package is None
+            or package.__dict__.get(_ARTIFACT_PATH_ATTRIBUTE) is None
+        ):
+            return None
+
+        spec = PathFinder.find_spec(fullname, path, target)
+        if spec is not None and spec.loader is not None:
+            spec.loader = _NamespaceLoader(spec.loader, namespace)
+        return spec
+
+
+def _install_finder() -> None:
+    if any(getattr(finder, _FINDER_MARKER, False) for finder in sys.meta_path):
+        return
+    sys.meta_path.insert(0, _NamespaceFinder())
+
+
+_install_finder()

--- a/python/flink_agents/plan/resource_provider.py
+++ b/python/flink_agents/plan/resource_provider.py
@@ -19,7 +19,7 @@ import importlib
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from flink_agents.api.resource import (
     Resource,
@@ -29,6 +29,7 @@ from flink_agents.api.resource import (
     get_resource_class,
 )
 from flink_agents.api.resource_context import ResourceContext
+from flink_agents.plan import module_namespace
 from flink_agents.plan.configuration import AgentConfiguration
 
 
@@ -46,6 +47,9 @@ class ResourceProvider(BaseModel, ABC):
 
     name: str
     type: ResourceType
+    _module_namespace: str | None = PrivateAttr(
+        default_factory=module_namespace.current
+    )
 
     @abstractmethod
     def provide(
@@ -108,6 +112,13 @@ class PythonResourceProvider(ResourceProvider):
         self, resource_context: ResourceContext, config: AgentConfiguration
     ) -> Resource:
         """Create resource in runtime."""
+        if self._module_namespace is not None and self.descriptor._clazz is None:
+            module = importlib.import_module(
+                module_namespace.qualify(
+                    self._module_namespace, self.descriptor.target_module
+                )
+            )
+            self.descriptor._clazz = getattr(module, self.descriptor.target_clazz)
         cls = self.descriptor.clazz
 
         final_kwargs = {}
@@ -154,10 +165,13 @@ class PythonSerializableResourceProvider(SerializableResourceProvider):
     ) -> Resource:
         """Get or deserialize resource in runtime."""
         if self.resource is None:
-            module = importlib.import_module(self.module)
+            module = importlib.import_module(
+                module_namespace.qualify(self._module_namespace, self.module)
+            )
             clazz = getattr(module, self.clazz)
             self.serialized["resource_context"] = resource_context
-            self.resource = clazz.model_validate(self.serialized)
+            with module_namespace.bind(self._module_namespace):
+                self.resource = clazz.model_validate(self.serialized)
         return self.resource
 
 

--- a/python/flink_agents/plan/tests/dynamic_plan_test_actions.py
+++ b/python/flink_agents/plan/tests/dynamic_plan_test_actions.py
@@ -1,0 +1,30 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from flink_agents.api.events.event import Event, InputEvent, OutputEvent
+from flink_agents.api.runner_context import RunnerContext
+
+
+def old_action(event: Event, ctx: RunnerContext) -> None:
+    value = InputEvent.from_event(event).input
+    ctx.send_event(OutputEvent(output=f"python-old:{value}"))
+
+
+def new_action(event: Event, ctx: RunnerContext) -> None:
+    value = InputEvent.from_event(event).input
+    ctx.send_event(OutputEvent(output=f"python-new:{value}"))

--- a/python/flink_agents/plan/tests/test_module_namespace.py
+++ b/python/flink_agents/plan/tests/test_module_namespace.py
@@ -1,0 +1,573 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import asyncio
+import importlib
+import json
+import sys
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import Mock
+
+import pytest
+
+from flink_agents.plan import module_namespace
+
+
+def _artifact(path: Path, value: int) -> Path:
+    sources = {
+        "app/__init__.py": "",
+        "app/utils/__init__.py": "",
+        "app/utils/data_type.py": f"VALUE = {value}\n",
+        "app/agent.py": (
+            "def value():\n"
+            "    from app.utils import data_type\n\n"
+            "    return data_type.VALUE\n"
+        ),
+        "app/resources.py": (
+            "class VersionedResource:\n"
+            "    def __init__(self):\n"
+            f"        self.value = {value}\n"
+        ),
+        "app/tools.py": (
+            f'def lookup():\n    """Return the version value."""\n    return {value}\n'
+        ),
+    }
+    with zipfile.ZipFile(path, "w") as artifact:
+        for relative_path, source in sources.items():
+            artifact.writestr(relative_path, source)
+    return path
+
+
+def _write_artifact(path: Path, sources: dict[str, str]) -> Path:
+    with zipfile.ZipFile(path, "w") as artifact:
+        for relative_path, source in sources.items():
+            artifact.writestr(relative_path, source)
+    return path
+
+
+def _drop(namespace: str) -> None:
+    module_namespace.drop(namespace)
+
+
+def test_plan_versions_keep_independent_absolute_import_graphs(
+    tmp_path: Path,
+) -> None:
+    namespace_v1 = "__fa_job_operator_v1"
+    namespace_v2 = "__fa_job_operator_v2"
+    artifact_v1 = _artifact(tmp_path / "v1.zip", 100)
+    artifact_v2 = _artifact(tmp_path / "v2.zip", 200)
+    bare_app_before = sys.modules.get("app")
+
+    try:
+        module_namespace.acquire(namespace_v1, artifact_v1)
+        module_namespace.acquire(namespace_v2, artifact_v2)
+        module_v1 = importlib.import_module(
+            module_namespace.qualify(namespace_v1, "app.agent")
+        )
+        module_v2 = importlib.import_module(
+            module_namespace.qualify(namespace_v2, "app.agent")
+        )
+
+        assert module_v1.value() == 100
+        assert module_v2.value() == 200
+        assert module_v1 is not module_v2
+        assert sys.modules.get("app") is bare_app_before
+        assert (
+            sys.modules[f"{namespace_v1}.app.utils.data_type"]
+            is not sys.modules[f"{namespace_v2}.app.utils.data_type"]
+        )
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+def test_shared_version_is_dropped_only_after_last_runtime_releases_it(
+    tmp_path: Path,
+) -> None:
+    namespace = "__fa_job_operator_v3"
+    artifact = _artifact(tmp_path / "v3.zip", 300)
+
+    try:
+        module_namespace.acquire(namespace, artifact)
+        module_namespace.acquire(namespace, artifact)
+        importlib.import_module(module_namespace.qualify(namespace, "app.agent"))
+
+        assert module_namespace.usage_count(namespace) == 2
+        assert module_namespace.release(namespace, drop_if_unused=True) is False
+        assert namespace in sys.modules
+        assert module_namespace.release(namespace, drop_if_unused=True) is True
+        assert namespace not in sys.modules
+    finally:
+        _drop(namespace)
+
+
+def test_namespace_cannot_be_reused_for_another_artifact(tmp_path: Path) -> None:
+    namespace = "__fa_job_operator_v4"
+    artifact_v1 = _artifact(tmp_path / "v4-a.zip", 400)
+    artifact_v2 = _artifact(tmp_path / "v4-b.zip", 401)
+
+    try:
+        module_namespace.acquire(namespace, artifact_v1)
+        with pytest.raises(ValueError, match="already registered"):
+            module_namespace.acquire(namespace, artifact_v2)
+    finally:
+        _drop(namespace)
+
+
+def test_runtime_resource_and_tool_entrypoints_use_plan_namespace(
+    tmp_path: Path,
+) -> None:
+    from flink_agents.runtime.python_java_utils import (
+        create_resource,
+        invoke_python_tool,
+    )
+
+    namespace_v1 = "__fa_job_operator_v5"
+    namespace_v2 = "__fa_job_operator_v6"
+    artifact_v1 = _artifact(tmp_path / "v5.zip", 500)
+    artifact_v2 = _artifact(tmp_path / "v6.zip", 600)
+
+    try:
+        module_namespace.acquire(namespace_v1, artifact_v1)
+        module_namespace.acquire(namespace_v2, artifact_v2)
+
+        resource_v1 = create_resource(
+            "app.resources", "VersionedResource", {}, namespace_v1
+        )
+        resource_v2 = create_resource(
+            "app.resources", "VersionedResource", {}, namespace_v2
+        )
+
+        assert resource_v1.value == 500
+        assert resource_v2.value == 600
+        assert invoke_python_tool("app.tools", "lookup", {}, namespace_v1) == 500
+        assert invoke_python_tool("app.tools", "lookup", {}, namespace_v2) == 600
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+@pytest.mark.parametrize(
+    ("import_source", "value_expression", "utils_init"),
+    [
+        (
+            "import app.utils.data_type\n",
+            "app.utils.data_type.VALUE",
+            "",
+        ),
+        (
+            "import app.utils.data_type as data_type\n",
+            "data_type.VALUE",
+            "",
+        ),
+        (
+            "from app.utils import data_type\n",
+            "data_type.VALUE",
+            "",
+        ),
+        (
+            "from app.utils.data_type import VALUE\n",
+            "VALUE",
+            "",
+        ),
+        (
+            "from .utils import data_type\n",
+            "data_type.VALUE",
+            "",
+        ),
+        (
+            "from .utils.data_type import VALUE\n",
+            "VALUE",
+            "",
+        ),
+        (
+            "from app.utils import VALUE\n",
+            "VALUE",
+            "from .data_type import VALUE\n",
+        ),
+    ],
+    ids=[
+        "absolute-import",
+        "absolute-import-alias",
+        "absolute-from-package",
+        "absolute-from-module",
+        "relative-from-package",
+        "relative-from-module",
+        "package-reexport",
+    ],
+)
+def test_common_import_forms_resolve_each_plan_dependency_version(
+    tmp_path: Path,
+    import_source: str,
+    value_expression: str,
+    utils_init: str,
+) -> None:
+    namespace_v1 = "__fa_import_forms_v1"
+    namespace_v2 = "__fa_import_forms_v2"
+
+    def import_artifact(path: Path, value: int) -> Path:
+        return _write_artifact(
+            path,
+            {
+                "app/__init__.py": "",
+                "app/utils/__init__.py": utils_init,
+                "app/utils/data_type.py": f"VALUE = {value}\n",
+                "app/agent.py": (
+                    import_source
+                    + "\n"
+                    + "def value():\n"
+                    + f"    return {value_expression}\n"
+                ),
+            },
+        )
+
+    try:
+        module_namespace.acquire(namespace_v1, import_artifact(tmp_path / "v1.zip", 10))
+        module_namespace.acquire(namespace_v2, import_artifact(tmp_path / "v2.zip", 20))
+
+        action_v1 = importlib.import_module(f"{namespace_v1}.app.agent")
+        action_v2 = importlib.import_module(f"{namespace_v2}.app.agent")
+
+        assert action_v1.value() == 10
+        assert action_v2.value() == 20
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+def test_action_and_tool_changes_use_their_own_transitive_dependencies(
+    tmp_path: Path,
+) -> None:
+    from flink_agents.runtime.python_java_utils import (
+        get_python_tool_metadata,
+        invoke_python_tool,
+    )
+
+    namespace_v1 = "__fa_action_tool_v1"
+    namespace_v2 = "__fa_action_tool_v2"
+
+    def action_tool_artifact(path: Path, version: str, offset: int) -> Path:
+        extra_parameter = "" if version == "v1" else ", scale: int = 2"
+        calculation = "value + OFFSET" if version == "v1" else "value * scale + OFFSET"
+        action_arguments = "value" if version == "v1" else "value, scale=3"
+        return _write_artifact(
+            path,
+            {
+                "app/__init__.py": "",
+                "app/shared.py": f"OFFSET = {offset}\n",
+                "app/tools.py": (
+                    "from app.shared import OFFSET\n\n"
+                    + f"def lookup(value: int{extra_parameter}) -> str:\n"
+                    + f'    """Lookup implemented by {version}."""\n'
+                    + f'    return f"tool-{version}:{{{calculation}}}"\n'
+                ),
+                "app/action.py": (
+                    "from app.tools import lookup\n\n"
+                    + "def handle(value: int) -> str:\n"
+                    + f'    return "action-{version}:" + lookup({action_arguments})\n'
+                ),
+            },
+        )
+
+    try:
+        module_namespace.acquire(
+            namespace_v1, action_tool_artifact(tmp_path / "v1.zip", "v1", 1)
+        )
+        module_namespace.acquire(
+            namespace_v2, action_tool_artifact(tmp_path / "v2.zip", "v2", 2)
+        )
+
+        action_v1 = importlib.import_module(f"{namespace_v1}.app.action")
+        action_v2 = importlib.import_module(f"{namespace_v2}.app.action")
+        metadata_v1 = get_python_tool_metadata(
+            "app.tools", "lookup", namespace=namespace_v1
+        )
+        metadata_v2 = get_python_tool_metadata(
+            "app.tools", "lookup", namespace=namespace_v2
+        )
+
+        assert action_v1.handle(4) == "action-v1:tool-v1:5"
+        assert action_v2.handle(4) == "action-v2:tool-v2:14"
+        assert metadata_v1["description"] == "Lookup implemented by v1."
+        assert metadata_v2["description"] == "Lookup implemented by v2."
+        assert "scale" not in metadata_v1["inputSchema"]
+        assert "scale" in metadata_v2["inputSchema"]
+        assert (
+            invoke_python_tool("app.tools", "lookup", {"value": 5}, namespace_v1)
+            == "tool-v1:6"
+        )
+        assert (
+            invoke_python_tool(
+                "app.tools", "lookup", {"value": 5, "scale": 4}, namespace_v2
+            )
+            == "tool-v2:22"
+        )
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+def test_resource_class_change_uses_the_matching_dependency_version(
+    tmp_path: Path,
+) -> None:
+    from flink_agents.runtime.python_java_utils import create_resource
+
+    namespace_v1 = "__fa_resource_dependency_v1"
+    namespace_v2 = "__fa_resource_dependency_v2"
+
+    def resource_artifact(path: Path, value: str) -> Path:
+        return _write_artifact(
+            path,
+            {
+                "app/__init__.py": "",
+                "app/settings.py": f'VALUE = "{value}"\n',
+                "app/resources.py": (
+                    "from app.settings import VALUE\n\n"
+                    "class VersionedResource:\n"
+                    "    def __init__(self):\n"
+                    "        self.value = VALUE\n"
+                ),
+            },
+        )
+
+    try:
+        module_namespace.acquire(
+            namespace_v1, resource_artifact(tmp_path / "v1.zip", "resource-v1")
+        )
+        module_namespace.acquire(
+            namespace_v2, resource_artifact(tmp_path / "v2.zip", "resource-v2")
+        )
+
+        resource_v1 = create_resource(
+            "app.resources", "VersionedResource", {}, namespace_v1
+        )
+        resource_v2 = create_resource(
+            "app.resources", "VersionedResource", {}, namespace_v2
+        )
+
+        assert resource_v1.value == "resource-v1"
+        assert resource_v2.value == "resource-v2"
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+def test_added_and_removed_modules_do_not_leak_between_plan_versions(
+    tmp_path: Path,
+) -> None:
+    namespace_v1 = "__fa_module_set_v1"
+    namespace_v2 = "__fa_module_set_v2"
+    artifact_v1 = _write_artifact(
+        tmp_path / "v1.zip",
+        {
+            "app/__init__.py": "",
+            "app/legacy.py": 'VALUE = "legacy"\n',
+            "app/agent.py": "from app.legacy import VALUE\n",
+        },
+    )
+    artifact_v2 = _write_artifact(
+        tmp_path / "v2.zip",
+        {
+            "app/__init__.py": "",
+            "app/fresh.py": 'VALUE = "fresh"\n',
+            "app/agent.py": "from app.fresh import VALUE\n",
+        },
+    )
+
+    try:
+        module_namespace.acquire(namespace_v1, artifact_v1)
+        module_namespace.acquire(namespace_v2, artifact_v2)
+        action_v1 = importlib.import_module(f"{namespace_v1}.app.agent")
+        action_v2 = importlib.import_module(f"{namespace_v2}.app.agent")
+
+        assert action_v1.VALUE == "legacy"
+        assert action_v2.VALUE == "fresh"
+        assert f"{namespace_v1}.app.legacy" in sys.modules
+        assert f"{namespace_v2}.app.legacy" not in sys.modules
+        assert f"{namespace_v2}.app.fresh" in sys.modules
+        assert f"{namespace_v1}.app.fresh" not in sys.modules
+
+        module_namespace.drop(namespace_v1)
+
+        assert action_v2.VALUE == "fresh"
+        assert f"{namespace_v2}.app.fresh" in sys.modules
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+def test_suspended_old_coroutine_keeps_its_dependency_graph_after_v2_loads(
+    tmp_path: Path,
+) -> None:
+    namespace_v1 = "__fa_async_reference_v1"
+    namespace_v2 = "__fa_async_reference_v2"
+
+    def async_artifact(path: Path, value: str) -> Path:
+        return _write_artifact(
+            path,
+            {
+                "app/__init__.py": "",
+                "app/value.py": f'VALUE = "{value}"\n',
+                "app/action.py": (
+                    "import asyncio\n"
+                    "from app.value import VALUE\n\n"
+                    "async def handle():\n"
+                    "    await asyncio.sleep(0)\n"
+                    "    return VALUE\n"
+                ),
+            },
+        )
+
+    async def exercise() -> tuple[str, str]:
+        module_namespace.acquire(
+            namespace_v1, async_artifact(tmp_path / "v1.zip", "async-v1")
+        )
+        action_v1 = importlib.import_module(f"{namespace_v1}.app.action")
+        suspended_v1 = asyncio.create_task(action_v1.handle())
+        await asyncio.sleep(0)
+
+        module_namespace.acquire(
+            namespace_v2, async_artifact(tmp_path / "v2.zip", "async-v2")
+        )
+        action_v2 = importlib.import_module(f"{namespace_v2}.app.action")
+        return await suspended_v1, await action_v2.handle()
+
+    try:
+        assert asyncio.run(exercise()) == ("async-v1", "async-v2")
+    finally:
+        _drop(namespace_v1)
+        _drop(namespace_v2)
+
+
+@pytest.mark.parametrize(
+    "tool_call_async", [False, True], ids=["sync-tool-call", "async-tool-call"]
+)
+def test_builtin_tool_call_action_uses_rebuilt_context_plan_namespace(
+    tmp_path: Path,
+    tool_call_async: bool,
+) -> None:
+    from flink_agents.api.events.tool_event import ToolRequestEvent, ToolResponseEvent
+    from flink_agents.plan.actions.tool_call_action import process_tool_request
+    from flink_agents.runtime.flink_runner_context import FlinkRunnerContext
+
+    namespace_v1 = "__fa_builtin_tool_v1"
+    namespace_v2 = "__fa_builtin_tool_v2"
+
+    def tool_artifact(path: Path, version: str, offset: int) -> Path:
+        return _write_artifact(
+            path,
+            {
+                "app/__init__.py": "",
+                "app/shared.py": f"OFFSET = {offset}\n",
+                "app/tools.py": (
+                    "from app.shared import OFFSET\n\n"
+                    "def lookup(value: int) -> str:\n"
+                    f'    """Lookup implemented by {version}."""\n'
+                    f'    return f"{version}:{{value + OFFSET}}"\n'
+                ),
+            },
+        )
+
+    plan_json = json.dumps(
+        {
+            "actions": {},
+            "actions_by_event": {},
+            "resource_providers": {
+                "tool": {
+                    "lookup": {
+                        "name": "lookup",
+                        "type": "tool",
+                        "module": "flink_agents.plan.tools.function_tool",
+                        "clazz": "FunctionTool",
+                        "serialized": {
+                            "name": "lookup",
+                            "func": {
+                                "func_type": "PythonFunction",
+                                "module": "app.tools",
+                                "qualname": "lookup",
+                            },
+                            "injected_args": {},
+                            "metadata": None,
+                        },
+                        "__resource_provider_type__": (
+                            "PythonSerializableResourceProvider"
+                        ),
+                    }
+                }
+            },
+            "config": {"conf_data": {"tool-call.async": tool_call_async}},
+        }
+    )
+
+    async def invoke(context: FlinkRunnerContext) -> str:
+        async def execute_async(func: Callable[..., Any], **kwargs: Any) -> Any:
+            return func(**kwargs)
+
+        sent_events = []
+        resource_cache = context._FlinkRunnerContext__resource_cache
+        context.get_resource = resource_cache.get_resource
+        context.durable_execute = lambda func, **kwargs: func(**kwargs)
+        context.durable_execute_async = execute_async
+        context.send_event = sent_events.append
+        request = ToolRequestEvent(
+            model="test-model",
+            tool_calls=[
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": {"value": 5}},
+                }
+            ],
+        )
+
+        await process_tool_request(request, context)
+
+        response = ToolResponseEvent.from_event(sent_events[0])
+        assert response.success["call-1"] is True, response.error
+        return response.responses["call-1"]
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    context_v1 = None
+    context_v2 = None
+    try:
+        module_namespace.acquire(
+            namespace_v1, tool_artifact(tmp_path / "v1.zip", "tool-v1", 1)
+        )
+        context_v1 = FlinkRunnerContext(
+            Mock(), plan_json, executor, Mock(), namespace_v1
+        )
+        assert asyncio.run(invoke(context_v1)) == "tool-v1:6"
+
+        module_namespace.acquire(
+            namespace_v2, tool_artifact(tmp_path / "v2.zip", "tool-v2", 2)
+        )
+        context_v2 = FlinkRunnerContext(
+            Mock(), plan_json, executor, Mock(), namespace_v2
+        )
+        assert asyncio.run(invoke(context_v2)) == "tool-v2:7"
+    finally:
+        if context_v1 is not None:
+            context_v1.close()
+        if context_v2 is not None:
+            context_v2.close()
+        executor.shutdown(wait=True)
+        _drop(namespace_v1)
+        _drop(namespace_v2)

--- a/python/flink_agents/runtime/agent_plan_client.py
+++ b/python/flink_agents/runtime/agent_plan_client.py
@@ -1,0 +1,123 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from types import TracebackType
+from typing import Any, Mapping, Type
+
+from pyflink.java_gateway import get_gateway
+from pyflink.util.java_utils import invoke_method
+from typing_extensions import Self
+
+from flink_agents.api.agent_plan_client import AgentPlanClient, PlanUpdateResult
+from flink_agents.api.agents.agent import Agent
+from flink_agents.plan.agent_plan import AgentPlan
+from flink_agents.plan.configuration import AgentConfiguration
+
+_JAVA_CLIENT_CLASS = "org.apache.flink.agents.runtime.client.AgentPlanClient"
+_JAVA_INTEGER = "java.lang.Integer"
+_JAVA_STRING = "java.lang.String"
+
+
+class RemoteAgentPlanClient(AgentPlanClient):
+    """AgentPlan client backed by Flink's Java RestClusterClient."""
+
+    def __init__(self, java_client: object) -> None:
+        """Wrap an initialized Java AgentPlanClient."""
+        self._java_client = java_client
+        self._closed = False
+
+    def update_agent_plan(
+        self, job_id: str, agent_name: str, agent_plan_json: str
+    ) -> PlanUpdateResult:
+        """Validate and submit a complete AgentPlan JSON document."""
+        self._ensure_open()
+        _validate_agent_name(agent_name)
+        java_result = invoke_method(
+            self._java_client,
+            _JAVA_CLIENT_CLASS,
+            "updateAgentPlan",
+            [job_id, agent_name, agent_plan_json],
+            [_JAVA_STRING, _JAVA_STRING, _JAVA_STRING],
+        )
+        return PlanUpdateResult(
+            plan_version=java_result.getPlanVersion(),
+            plan_id=java_result.getPlanId(),
+            registered_subtasks=java_result.getRegisteredSubtasks(),
+        )
+
+    def update_agent(
+        self,
+        job_id: str,
+        agent: Agent,
+        name: str | None = None,
+        config: Mapping[str, Any] | None = None,
+    ) -> PlanUpdateResult:
+        """Compile an Agent with optional config data and submit it."""
+        agent_name = name if name is not None else agent.__class__.__name__
+        _validate_agent_name(agent_name)
+        agent_config = AgentConfiguration(dict(config) if config is not None else None)
+        plan = AgentPlan.from_agent(agent, agent_config)
+        return self.update_agent_plan(
+            job_id,
+            agent_name,
+            plan.model_dump_json(serialize_as_any=True),
+        )
+
+    def close(self) -> None:
+        """Close the Java REST client once."""
+        if self._closed:
+            return
+        self._closed = True
+        invoke_method(self._java_client, _JAVA_CLIENT_CLASS, "close", [], [])
+
+    def __enter__(self) -> Self:
+        """Return this client for use as a context manager."""
+        self._ensure_open()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close this client when leaving a context manager."""
+        self.close()
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            msg = "AgentPlanClient is already closed."
+            raise RuntimeError(msg)
+
+
+def create_instance(rest_address: str, rest_port: int) -> AgentPlanClient:
+    """Create a Python wrapper around the Java AgentPlanClient."""
+    java_port = get_gateway().jvm.java.lang.Integer(rest_port)
+    java_client = invoke_method(
+        None,
+        _JAVA_CLIENT_CLASS,
+        "create",
+        [rest_address, java_port],
+        [_JAVA_STRING, _JAVA_INTEGER],
+    )
+    return RemoteAgentPlanClient(java_client)
+
+
+def _validate_agent_name(agent_name: str) -> None:
+    if not agent_name or not agent_name.strip():
+        msg = "The agent name must not be blank."
+        raise ValueError(msg)

--- a/python/flink_agents/runtime/flink_runner_context.py
+++ b/python/flink_agents/runtime/flink_runner_context.py
@@ -38,6 +38,7 @@ from flink_agents.api.runner_context import (
     AsyncExecutionResult,
     RunnerContext,
 )
+from flink_agents.plan.function import bind_python_module_namespace
 from flink_agents.runtime.durable_execution import (
     _compute_args_digest,
     _compute_function_id,
@@ -257,6 +258,7 @@ class FlinkRunnerContext(RunnerContext):
         agent_plan_json: str,
         executor: ThreadPoolExecutor,
         j_resource_adapter: Any,
+        module_namespace: str | None = None,
     ) -> None:
         """Initialize a flink runner context with the given java runner context.
 
@@ -268,7 +270,8 @@ class FlinkRunnerContext(RunnerContext):
         from flink_agents.plan.agent_plan import AgentPlan
 
         self._j_runner_context = j_runner_context
-        self.__agent_plan = AgentPlan.model_validate_json(agent_plan_json)
+        with bind_python_module_namespace(module_namespace):
+            self.__agent_plan = AgentPlan.model_validate_json(agent_plan_json)
         self.__resource_cache = ResourceCache(
             self.__agent_plan.resource_providers, self.__agent_plan.config
         )
@@ -768,10 +771,15 @@ def create_flink_runner_context(
     executor: ThreadPoolExecutor,
     j_resource_adapter: Any,
     job_identifier: str,
+    module_namespace: str | None = None,
 ) -> FlinkRunnerContext:
     """Used to create a FlinkRunnerContext Python object in Pemja environment."""
     ctx = FlinkRunnerContext(
-        j_runner_context, agent_plan_json, executor, j_resource_adapter
+        j_runner_context,
+        agent_plan_json,
+        executor,
+        j_resource_adapter,
+        module_namespace,
     )
     ltm = _init_long_term_memory(ctx, job_identifier)
     if ltm is not None:

--- a/python/flink_agents/runtime/python_java_utils.py
+++ b/python/flink_agents/runtime/python_java_utils.py
@@ -36,6 +36,7 @@ from flink_agents.api.vector_stores.vector_store import (
     VectorStoreQuery,
     VectorStoreQueryMode,
 )
+from flink_agents.plan import module_namespace
 from flink_agents.plan.resource_provider import JAVA_RESOURCE_MAPPING
 from flink_agents.runtime.java.java_resource_wrapper import (
     JavaPrompt,
@@ -77,7 +78,10 @@ def get_output_from_output_event(event_json: str) -> Any:
 
 
 def create_resource(
-    resource_module: str, resource_clazz: str, func_kwargs: Dict[str, Any]
+    resource_module: str,
+    resource_clazz: str,
+    func_kwargs: Dict[str, Any],
+    namespace: str | None = None,
 ) -> Resource:
     """Dynamically create a resource instance from module and class name.
 
@@ -85,11 +89,14 @@ def create_resource(
         resource_module: The module path containing the resource class
         resource_clazz: The class name to instantiate
         func_kwargs: Keyword arguments to pass to the class constructor
+        namespace: Optional plan-version module namespace
 
     Returns:
         Resource: An instance of the specified resource class
     """
-    module = importlib.import_module(resource_module)
+    module = importlib.import_module(
+        module_namespace.qualify(namespace, resource_module)
+    )
     cls = getattr(module, resource_clazz)
     return cls(**func_kwargs)
 
@@ -128,7 +135,10 @@ def from_java_tool(j_tool: Any) -> JavaTool:
 
 
 def get_python_tool_metadata(
-    module: str, qual_name: str, injected_args: list[str] | None = None
+    module: str,
+    qual_name: str,
+    injected_args: list[str] | None = None,
+    namespace: str | None = None,
 ) -> Dict[str, str]:
     """Introspect a Python callable into the flat tool-metadata shape expected by
     the Java-side ``PythonResourceAdapter.getPythonToolMetadata``.
@@ -151,7 +161,9 @@ def get_python_tool_metadata(
         create_schema_from_function,
     )
 
-    descriptor = PythonFunction(module=module, qualname=qual_name)
+    descriptor = PythonFunction(
+        module=module_namespace.qualify(namespace, module), qualname=qual_name
+    )
     callable_ = descriptor.as_callable()
     name = callable_.__name__
     description = (parse(callable_.__doc__).description or "") if callable_.__doc__ else ""
@@ -178,7 +190,10 @@ def _dump_injected_args(injected_args: Dict[str, Any]) -> str:
 
 
 def invoke_python_tool(
-    module: str, qual_name: str, kwargs: Dict[str, Any]
+    module: str,
+    qual_name: str,
+    kwargs: Dict[str, Any],
+    namespace: str | None = None,
 ) -> Any:
     """Invoke a Python callable as a tool, passing the provided keyword arguments.
 
@@ -188,7 +203,9 @@ def invoke_python_tool(
     """
     from flink_agents.api.function import PythonFunction
 
-    descriptor = PythonFunction(module=module, qualname=qual_name)
+    descriptor = PythonFunction(
+        module=module_namespace.qualify(namespace, module), qualname=qual_name
+    )
     return descriptor.as_callable()(**kwargs)
 
 

--- a/python/flink_agents/runtime/remote_execution_environment.py
+++ b/python/flink_agents/runtime/remote_execution_environment.py
@@ -52,6 +52,7 @@ class RemoteAgentBuilder(AgentBuilder):
 
     __input: DataStream
     __agent_plan: AgentPlan = None
+    __agent_name: str = None
     __output: DataStream = None
     __t_env: StreamTableEnvironment
     __config: AgentConfiguration
@@ -82,7 +83,9 @@ class RemoteAgentBuilder(AgentBuilder):
             )
         return self.__t_env
 
-    def apply(self, agent: Agent | str) -> "AgentBuilder":
+    def apply(
+        self, agent: Agent | str, name: str | None = None
+    ) -> "AgentBuilder":
         """Set agent of execution environment.
 
         Parameters
@@ -90,6 +93,9 @@ class RemoteAgentBuilder(AgentBuilder):
         agent : Agent | str
             Either an Agent instance, or the name of an agent registered
             on the environment (e.g. by ``load_yaml``).
+        name : str, optional
+            Stable deployment name. Defaults to the Agent class name, or to
+            the registry name when ``agent`` is a string.
         """
         if self.__agent_plan is not None:
             err_msg = "RemoteAgentBuilder doesn't support apply multiple agents yet."
@@ -101,13 +107,21 @@ class RemoteAgentBuilder(AgentBuilder):
                     "environment. Did you call load_yaml first?"
                 )
                 raise ValueError(msg)
+            agent_name = name if name is not None else agent
             agent = self.__agents[agent]
+        else:
+            agent_name = name if name is not None else agent.__class__.__name__
+
+        if not agent_name or not agent_name.strip():
+            msg = "The agent name must not be blank."
+            raise ValueError(msg)
 
         # inspect refer actions and resources from env to agent.
         for type, name_to_resource in self.__resources.items():
             agent.resources[type] = name_to_resource | agent.resources[type]
 
         self.__agent_plan = AgentPlan.from_agent(agent, self.__config)
+        self.__agent_name = agent_name
 
         return self
 
@@ -131,10 +145,12 @@ class RemoteAgentBuilder(AgentBuilder):
                 "connectToAgent",
                 [
                     self.__input._j_data_stream,
+                    self.__agent_name,
                     self.__agent_plan.model_dump_json(serialize_as_any=True),
                 ],
                 [
                     "org.apache.flink.streaming.api.datastream.KeyedStream",
+                    "java.lang.String",
                     "java.lang.String",
                 ],
             )

--- a/python/flink_agents/runtime/tests/test_agent_plan_client.py
+++ b/python/flink_agents/runtime/tests/test_agent_plan_client.py
@@ -1,0 +1,203 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#################################################################################
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flink_agents.api.agent_plan_client import AgentPlanClient, PlanUpdateResult
+from flink_agents.api.agents.agent import Agent
+from flink_agents.runtime.agent_plan_client import (
+    RemoteAgentPlanClient,
+    create_instance,
+)
+
+
+def test_factory_loads_version_jar_before_creating_runtime_client() -> None:
+    """The independent client bootstraps its Java classes without an execution env."""
+    expected = MagicMock()
+    runtime_module = MagicMock()
+    runtime_module.create_instance.return_value = expected
+
+    with (
+        patch(
+            "flink_agents.api.agent_plan_client.add_flink_agents_jars_to_context_class_loader"
+        ) as add_jars,
+        patch(
+            "flink_agents.api.agent_plan_client.importlib.import_module",
+            return_value=runtime_module,
+        ),
+    ):
+        actual = AgentPlanClient.create("localhost", 8081)
+
+    assert actual is expected
+    add_jars.assert_called_once_with()
+    runtime_module.create_instance.assert_called_once_with("localhost", 8081)
+
+
+def test_runtime_factory_invokes_boxed_integer_java_bridge() -> None:
+    """The PyFlink reflection helper resolves the boxed Integer type."""
+    java_client = MagicMock()
+    java_port = MagicMock()
+    gateway = MagicMock()
+    gateway.jvm.java.lang.Integer.return_value = java_port
+
+    with (
+        patch(
+            "flink_agents.runtime.agent_plan_client.invoke_method",
+            return_value=java_client,
+        ) as invoke,
+        patch(
+            "flink_agents.runtime.agent_plan_client.get_gateway",
+            return_value=gateway,
+        ),
+    ):
+        actual = create_instance("localhost", 8081)
+
+    assert isinstance(actual, RemoteAgentPlanClient)
+    assert invoke.call_args.args[2] == "create"
+    assert invoke.call_args.args[3] == ["localhost", java_port]
+    assert invoke.call_args.args[4] == ["java.lang.String", "java.lang.Integer"]
+
+
+@pytest.mark.parametrize(
+    ("rest_address", "rest_port"),
+    [("", 8081), (" ", 8081), ("localhost", 0), ("localhost", 65536)],
+)
+def test_factory_rejects_invalid_endpoint(rest_address: str, rest_port: int) -> None:
+    with pytest.raises(ValueError, match="REST"):
+        AgentPlanClient.create(rest_address, rest_port)
+
+
+def test_update_plan_json_invokes_java_bridge_and_converts_result() -> None:
+    """Python sends strings only and exposes an immutable Python result."""
+    java_client = MagicMock()
+    java_result = MagicMock()
+    java_result.getPlanVersion.return_value = 4
+    java_result.getPlanId.return_value = "plan-id"
+    java_result.getRegisteredSubtasks.return_value = 2
+    client = RemoteAgentPlanClient(java_client)
+
+    with patch(
+        "flink_agents.runtime.agent_plan_client.invoke_method",
+        return_value=java_result,
+    ) as invoke:
+        result = client.update_agent_plan("0" * 32, "review-agent", '{"actions":{}}')
+
+    assert result == PlanUpdateResult(
+        plan_version=4, plan_id="plan-id", registered_subtasks=2
+    )
+    assert invoke.call_args.args[2] == "updateAgentPlan"
+    assert invoke.call_args.args[3] == [
+        "0" * 32,
+        "review-agent",
+        '{"actions":{}}',
+    ]
+    assert invoke.call_args.args[4] == [
+        "java.lang.String",
+        "java.lang.String",
+        "java.lang.String",
+    ]
+
+
+def test_update_agent_builds_plan_and_defaults_to_class_name() -> None:
+    """The convenience API reuses Agent-to-AgentPlan compilation."""
+    client = RemoteAgentPlanClient(MagicMock())
+    expected = PlanUpdateResult(2, "plan-id", 1)
+
+    with patch.object(
+        client, "update_agent_plan", return_value=expected
+    ) as update_plan:
+        actual = client.update_agent("0" * 32, NamedAgent())
+
+    assert actual == expected
+    assert update_plan.call_args.args[1] == "NamedAgent"
+    assert '"actions"' in update_plan.call_args.args[2]
+
+
+def test_update_agent_accepts_explicit_deployment_name() -> None:
+    """Updates can target a stable name after the Agent class changes."""
+    client = RemoteAgentPlanClient(MagicMock())
+    expected = PlanUpdateResult(2, "plan-id", 1)
+
+    with patch.object(
+        client, "update_agent_plan", return_value=expected
+    ) as update_plan:
+        client.update_agent("0" * 32, NamedAgent(), name="review-agent")
+
+    assert update_plan.call_args.args[1] == "review-agent"
+
+
+def test_update_agent_builds_plan_with_explicit_config_mapping() -> None:
+    """The independent client accepts config data without an execution env."""
+    client = RemoteAgentPlanClient(MagicMock())
+    expected = PlanUpdateResult(2, "plan-id", 1)
+
+    with patch.object(
+        client, "update_agent_plan", return_value=expected
+    ) as update_plan:
+        client.update_agent(
+            "0" * 32,
+            NamedAgent(),
+            config={"dynamic-plan.test-key": "test-value"},
+        )
+
+    assert '"dynamic-plan.test-key":"test-value"' in update_plan.call_args.args[2]
+
+
+def test_client_context_manager_closes_once() -> None:
+    """The wrapper owns and closes its Java RestClusterClient."""
+    java_client = MagicMock()
+    client = RemoteAgentPlanClient(java_client)
+
+    with patch("flink_agents.runtime.agent_plan_client.invoke_method") as invoke:
+        with client as entered:
+            assert entered is client
+        client.close()
+
+    close_calls = [call for call in invoke.call_args_list if call.args[2] == "close"]
+    assert len(close_calls) == 1
+
+
+def test_update_after_close_is_rejected() -> None:
+    """A closed wrapper never invokes the Java client again."""
+    client = RemoteAgentPlanClient(MagicMock())
+
+    with patch("flink_agents.runtime.agent_plan_client.invoke_method"):
+        client.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        client.update_agent_plan("0" * 32, "review-agent", "{}")
+
+
+def test_close_failure_still_marks_client_closed() -> None:
+    """A partially closed Java client is never invoked a second time."""
+    client = RemoteAgentPlanClient(MagicMock())
+
+    with patch(
+        "flink_agents.runtime.agent_plan_client.invoke_method",
+        side_effect=RuntimeError("close failed"),
+    ) as invoke:
+        with pytest.raises(RuntimeError, match="close failed"):
+            client.close()
+        client.close()
+
+    invoke.assert_called_once()
+
+
+class NamedAgent(Agent):
+    """Agent with a deterministic deployment name."""

--- a/python/flink_agents/runtime/tests/test_remote_execution_environment.py
+++ b/python/flink_agents/runtime/tests/test_remote_execution_environment.py
@@ -23,8 +23,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from flink_agents.api.agents.agent import Agent
+from flink_agents.api.resource import ResourceType
 from flink_agents.plan.configuration import AgentConfiguration
 from flink_agents.runtime.remote_execution_environment import (
+    RemoteAgentBuilder,
     RemoteExecutionEnvironment,
 )
 
@@ -218,6 +221,74 @@ def test_apply_by_unknown_name_errors() -> None:
 
     with pytest.raises(ValueError, match="ghost"):
         builder.apply("ghost")
+
+
+def test_apply_uses_agent_class_name_as_deployment_name() -> None:
+    """An Agent instance defaults its deployment identity to its class name."""
+    builder = _remote_agent_builder()
+
+    builder.apply(NamedAgent())
+
+    assert _compiled_agent_name(builder) == "NamedAgent"
+
+
+def test_apply_accepts_explicit_deployment_name() -> None:
+    """Users can keep a stable deployment identity across class renames."""
+    builder = _remote_agent_builder()
+
+    builder.apply(NamedAgent(), name="review-agent")
+
+    assert _compiled_agent_name(builder) == "review-agent"
+
+
+def test_apply_registered_agent_uses_registry_name() -> None:
+    """YAML/registry lookup names are also the deployed agent identity."""
+    builder = _remote_agent_builder(agents={"yaml-agent": NamedAgent()})
+
+    builder.apply("yaml-agent")
+
+    assert _compiled_agent_name(builder) == "yaml-agent"
+
+
+def test_apply_rejects_blank_deployment_name() -> None:
+    """Blank names cannot produce a stable operator UID."""
+    builder = _remote_agent_builder()
+
+    with pytest.raises(ValueError, match="agent name"):
+        builder.apply(NamedAgent(), name="  ")
+
+
+class NamedAgent(Agent):
+    """Agent with a deterministic default deployment name."""
+
+
+def _remote_agent_builder(
+    agents: dict[str, Agent] | None = None,
+) -> RemoteAgentBuilder:
+    input_stream = MagicMock()
+    input_stream._j_data_stream = MagicMock()
+    resources = {resource_type: {} for resource_type in ResourceType}
+    return RemoteAgentBuilder(
+        input=input_stream,
+        config=AgentConfiguration(),
+        resources=resources,
+        agents=agents,
+    )
+
+
+def _compiled_agent_name(builder: RemoteAgentBuilder) -> str:
+    wrapped_output = MagicMock()
+    with (
+        patch(
+            "flink_agents.runtime.remote_execution_environment.invoke_method"
+        ) as invoke,
+        patch(
+            "flink_agents.runtime.remote_execution_environment.DataStream",
+            return_value=wrapped_output,
+        ),
+    ):
+        builder.to_datastream()
+    return invoke.call_args.args[3][1]
 
 
 def _verify_config(config: AgentConfiguration) -> None:

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
@@ -27,28 +27,34 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
 
 /** A utility class that bridges Flink DataStream/SQL with the Flink Agents agent. */
 public class CompileUtils {
 
     // ============================ invoke by python ====================================
     public static DataStream<byte[]> connectToAgent(
-            KeyedStream<Row, Row> inputDataStream, String agentPlanJson)
+            KeyedStream<Row, Row> inputDataStream, String agentName, String agentPlanJson)
             throws JsonProcessingException {
         // deserialize agent plan json.
         AgentPlan agentPlan = new ObjectMapper().readValue(agentPlanJson, AgentPlan.class);
-        return connectToAgent(inputDataStream, agentPlan, TypeInformation.of(byte[].class), false);
+        return connectToAgent(
+                inputDataStream, agentName, agentPlan, TypeInformation.of(byte[].class), false);
     }
 
     // ============================ invoke by java ====================================
     public static <IN, K> DataStream<Object> connectToAgent(
-            DataStream<IN> inputStream, KeySelector<IN, K> keySelector, AgentPlan agentPlan) {
-        return connectToAgent(inputStream.keyBy(keySelector), agentPlan);
+            DataStream<IN> inputStream,
+            KeySelector<IN, K> keySelector,
+            String agentName,
+            AgentPlan agentPlan) {
+        return connectToAgent(inputStream.keyBy(keySelector), agentName, agentPlan);
     }
 
     public static <IN, K> DataStream<Object> connectToAgent(
-            KeyedStream<IN, K> keyedInputStream, AgentPlan agentPlan) {
-        return connectToAgent(keyedInputStream, agentPlan, TypeInformation.of(Object.class), true);
+            KeyedStream<IN, K> keyedInputStream, String agentName, AgentPlan agentPlan) {
+        return connectToAgent(
+                keyedInputStream, agentName, agentPlan, TypeInformation.of(Object.class), true);
     }
 
     // ============================ basic ====================================
@@ -71,15 +77,40 @@ public class CompileUtils {
      */
     private static <K, IN, OUT> DataStream<OUT> connectToAgent(
             KeyedStream<IN, K> keyedInputStream,
+            String agentName,
             AgentPlan agentPlan,
             TypeInformation<OUT> outTypeInformation,
             boolean inputIsJava) {
+        validateAgentName(agentName);
         return (DataStream<OUT>)
                 keyedInputStream
                         .transform(
-                                "action-execute-operator",
+                                getOperatorName(agentName),
                                 outTypeInformation,
                                 new ActionExecutionOperatorFactory(agentPlan, inputIsJava))
+                        .uid(getCoordinatedOperatorUid(agentName))
                         .setParallelism(keyedInputStream.getParallelism());
+    }
+
+    private static final String COORDINATED_OPERATOR_UID_PREFIX =
+            "flink-agents-coordinated-operator:";
+
+    private static final String COORDINATED_OPERATOR_NAME_PREFIX =
+            "coordinated-action-execute-operator:";
+
+    public static void validateAgentName(String agentName) {
+        Preconditions.checkArgument(
+                agentName != null && !agentName.trim().isEmpty(),
+                "The agent name must not be blank.");
+    }
+
+    public static String getCoordinatedOperatorUid(String agentName) {
+        validateAgentName(agentName);
+        return COORDINATED_OPERATOR_UID_PREFIX + agentName;
+    }
+
+    private static String getOperatorName(String agentName) {
+        validateAgentName(agentName);
+        return COORDINATED_OPERATOR_NAME_PREFIX + agentName;
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/CompileUtils.java
@@ -21,7 +21,8 @@ package org.apache.flink.agents.runtime;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.agents.plan.AgentPlan;
-import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorFactory;
+import org.apache.flink.agents.runtime.operator.CoordinatedActionExecutionOperatorFactory;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -81,15 +82,8 @@ public class CompileUtils {
             AgentPlan agentPlan,
             TypeInformation<OUT> outTypeInformation,
             boolean inputIsJava) {
-        validateAgentName(agentName);
-        return (DataStream<OUT>)
-                keyedInputStream
-                        .transform(
-                                getOperatorName(agentName),
-                                outTypeInformation,
-                                new ActionExecutionOperatorFactory(agentPlan, inputIsJava))
-                        .uid(getCoordinatedOperatorUid(agentName))
-                        .setParallelism(keyedInputStream.getParallelism());
+        return coordinatedConnect(
+                keyedInputStream, agentName, agentPlan, outTypeInformation, inputIsJava);
     }
 
     private static final String COORDINATED_OPERATOR_UID_PREFIX =
@@ -109,8 +103,41 @@ public class CompileUtils {
         return COORDINATED_OPERATOR_UID_PREFIX + agentName;
     }
 
-    private static String getOperatorName(String agentName) {
+    private static String getCoordinatedOperatorName(String agentName) {
         validateAgentName(agentName);
         return COORDINATED_OPERATOR_NAME_PREFIX + agentName;
+    }
+
+    /**
+     * The only wiring: the agent operator is always coordinated, so every job can receive plan
+     * updates as OperatorEvents from the JM-side coordinator without opting in. Each deployment
+     * gets a stable uid derived from its agent name; {@code AgentPlanClient} uses that same name to
+     * address exactly one coordinator. Jobs built with releases before this feature keep running on
+     * their release; upgrading changes the operator uid and therefore requires a fresh start (no
+     * state compatibility is provided).
+     */
+    private static <K, IN, OUT> DataStream<OUT> coordinatedConnect(
+            KeyedStream<IN, K> keyedInputStream,
+            String agentName,
+            AgentPlan agentPlan,
+            TypeInformation<OUT> outTypeInformation,
+            boolean inputIsJava) {
+        validateAgentName(agentName);
+        return (DataStream<OUT>)
+                keyedInputStream
+                        .transform(
+                                getCoordinatedOperatorName(agentName),
+                                outTypeInformation,
+                                new CoordinatedActionExecutionOperatorFactory<>(
+                                        agentPlan, inputIsJava))
+                        .uid(getCoordinatedOperatorUid(agentName))
+                        .setParallelism(keyedInputStream.getParallelism());
+    }
+
+    @VisibleForTesting
+    public static <IN, K> DataStream<Object> connectToAgentWithCoordinator(
+            KeyedStream<IN, K> keyedInputStream, String agentName, AgentPlan agentPlan) {
+        return coordinatedConnect(
+                keyedInputStream, agentName, agentPlan, TypeInformation.of(Object.class), true);
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateStore.java
@@ -90,4 +90,12 @@ public interface ActionStateStore extends AutoCloseable {
     default Object getRecoveryMarker() {
         return null;
     }
+
+    /**
+     * Scopes subsequently generated state keys by the content identity of the plan now live on this
+     * subtask. Implementations without dynamic plan support may ignore this.
+     *
+     * @param planId the coordinator-minted content identity of the live plan
+     */
+    default void setActivePlanId(String planId) {}
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtil.java
@@ -25,6 +25,7 @@ import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -44,21 +45,44 @@ public class ActionStateUtil {
     public static String generateKey(
             @Nonnull Object key, long seqNum, @Nonnull Action action, @Nonnull Event event)
             throws IOException {
+        return generateKey(key, seqNum, action, event, null);
+    }
+
+    /**
+     * Variant scoped by a dynamic plan's content identity. Results written by different plans are
+     * isolated, while resubmitting the same plan under a new planVersion reuses the same scope. A
+     * null planId is reserved for standalone, unscoped store use.
+     */
+    public static String generateKey(
+            @Nonnull Object key,
+            long seqNum,
+            @Nonnull Action action,
+            @Nonnull Event event,
+            @Nullable String planId)
+            throws IOException {
         Preconditions.checkNotNull(key, "key cannot be null.");
         Preconditions.checkNotNull(action, "action cannot be null.");
         Preconditions.checkNotNull(event, "event cannot be null.");
-        return String.join(
-                KEY_SEPARATOR,
-                key.toString(),
-                String.valueOf(seqNum),
-                generateUUIDForEvent(event),
-                generateUUIDForAction(action));
+        String baseKey =
+                String.join(
+                        KEY_SEPARATOR,
+                        key.toString(),
+                        String.valueOf(seqNum),
+                        generateUUIDForEvent(event),
+                        generateUUIDForAction(action));
+        if (planId == null) {
+            return baseKey;
+        }
+        Preconditions.checkArgument(
+                planId.matches("[0-9a-f]{64}"),
+                "planId must contain exactly 64 lowercase hexadecimal characters.");
+        return String.join(KEY_SEPARATOR, baseKey, planId);
     }
 
     public static List<String> parseKey(String key) {
         Preconditions.checkNotNull(key, "key cannot be null.");
         String[] parts = key.split(KEY_SEPARATOR);
-        Preconditions.checkArgument(parts.length == 4, "Invalid key format.");
+        Preconditions.checkArgument(parts.length == 4 || parts.length == 5, "Invalid key format.");
         return List.of(parts);
     }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStore.java
@@ -189,10 +189,18 @@ public class FlussActionStateStore implements ActionStateStore {
                 tableName);
     }
 
+    // Null only before an owner selects a plan scope (for standalone store use).
+    private volatile String activePlanId;
+
+    @Override
+    public void setActivePlanId(String planId) {
+        this.activePlanId = Preconditions.checkNotNull(planId, "planId must not be null");
+    }
+
     @Override
     public void put(Object key, long seqNum, Action action, Event event, ActionState state)
             throws Exception {
-        String stateKey = generateKey(key, seqNum, action, event);
+        String stateKey = generateKey(key, seqNum, action, event, activePlanId);
         byte[] payload = ActionStateSerde.serialize(state);
 
         GenericRow row =
@@ -214,13 +222,13 @@ public class FlussActionStateStore implements ActionStateStore {
 
     @Override
     public ActionState get(Object key, long seqNum, Action action, Event event) throws Exception {
-        String stateKey = generateKey(key, seqNum, action, event);
+        String stateKey = generateKey(key, seqNum, action, event, activePlanId);
         String keyPrefix = key.toString() + "_";
 
         boolean hasDivergence = checkDivergence(key.toString(), seqNum);
 
         if (!actionStates.containsKey(stateKey) || hasDivergence) {
-            removeStateEntries(keyPrefix, stateSeqNum -> stateSeqNum > seqNum);
+            removeStateEntries(keyPrefix, stateSeqNum -> stateSeqNum > seqNum, true);
         }
 
         ActionState state = actionStates.get(stateKey);
@@ -231,8 +239,16 @@ public class FlussActionStateStore implements ActionStateStore {
     private boolean checkDivergence(String key, long seqNum) {
         return actionStates.keySet().stream()
                         .filter(k -> k.startsWith(key + "_" + seqNum + "_"))
+                        .filter(this::isInActivePlanScope)
                         .count()
                 > 1;
+    }
+
+    private boolean isInActivePlanScope(String stateKey) {
+        if (activePlanId == null) {
+            return ActionStateUtil.parseKey(stateKey).size() == 4;
+        }
+        return stateKey.endsWith("_" + activePlanId);
     }
 
     /**
@@ -240,11 +256,17 @@ public class FlussActionStateStore implements ActionStateStore {
      * sequence number satisfies {@code seqNumFilter}.
      */
     private void removeStateEntries(String keyPrefix, LongPredicate seqNumFilter) {
+        removeStateEntries(keyPrefix, seqNumFilter, false);
+    }
+
+    private void removeStateEntries(
+            String keyPrefix, LongPredicate seqNumFilter, boolean activePlanOnly) {
         actionStates
                 .entrySet()
                 .removeIf(
                         entry -> {
-                            if (!entry.getKey().startsWith(keyPrefix)) {
+                            if (!entry.getKey().startsWith(keyPrefix)
+                                    || (activePlanOnly && !isInActivePlanScope(entry.getKey()))) {
                                 return false;
                             }
                             try {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStore.java
@@ -123,6 +123,14 @@ public class KafkaActionStateStore implements ActionStateStore {
         LOG.info("Initialized KafkaActionStateStore with topic: {}", topic);
     }
 
+    // Null only before an owner selects a plan scope (for standalone store use).
+    private volatile String activePlanId;
+
+    @Override
+    public void setActivePlanId(String planId) {
+        this.activePlanId = Preconditions.checkArgumentNotNull(planId, "planId must not be null");
+    }
+
     @Override
     public void put(Object key, long seqNum, Action action, Event event, ActionState state)
             throws Exception {
@@ -131,7 +139,7 @@ public class KafkaActionStateStore implements ActionStateStore {
             return;
         }
 
-        String stateKey = generateKey(key, seqNum, action, event);
+        String stateKey = generateKey(key, seqNum, action, event, activePlanId);
         try {
             ProducerRecord<String, ActionState> kafkaRecord =
                     new ProducerRecord<>(topic, stateKey, state);
@@ -149,7 +157,7 @@ public class KafkaActionStateStore implements ActionStateStore {
 
     @Override
     public ActionState get(Object key, long seqNum, Action action, Event event) throws Exception {
-        String stateKey = generateKey(key, seqNum, action, event);
+        String stateKey = generateKey(key, seqNum, action, event, activePlanId);
 
         LOG.debug(
                 "Looking up action state: key={}, seqNum={}, stateKey={}, cachedStates={}",
@@ -161,10 +169,15 @@ public class KafkaActionStateStore implements ActionStateStore {
         boolean hasDivergence = checkDivergence(key.toString(), seqNum);
 
         if (!actionStates.containsKey(stateKey) || hasDivergence) {
+            String keyPrefix = key + "_";
             actionStates
                     .entrySet()
                     .removeIf(
                             entry -> {
+                                if (!entry.getKey().startsWith(keyPrefix)
+                                        || !isInActivePlanScope(entry.getKey())) {
+                                    return false;
+                                }
                                 // Extract key and sequence number from the state key
                                 try {
                                     List<String> parts = ActionStateUtil.parseKey(entry.getKey());
@@ -174,10 +187,10 @@ public class KafkaActionStateStore implements ActionStateStore {
                                         // the requested seqNum
                                         return stateSeqNum > seqNum;
                                     }
-                                } catch (NumberFormatException e) {
+                                } catch (RuntimeException e) {
                                     LOG.warn(
                                             "Failed to parse sequence number from state key: {}",
-                                            stateKey);
+                                            entry.getKey());
                                 }
                                 return false;
                             });
@@ -196,8 +209,16 @@ public class KafkaActionStateStore implements ActionStateStore {
     private boolean checkDivergence(String key, long seqNum) {
         return actionStates.keySet().stream()
                         .filter(k -> k.startsWith(key + "_" + seqNum + "_"))
+                        .filter(this::isInActivePlanScope)
                         .count()
                 > 1;
+    }
+
+    private boolean isInActivePlanScope(String stateKey) {
+        if (activePlanId == null) {
+            return ActionStateUtil.parseKey(stateKey).size() == 4;
+        }
+        return stateKey.endsWith("_" + activePlanId);
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/client/AgentPlanClient.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/client/AgentPlanClient.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.CompileUtils;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateRequest;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateResponse;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.ExecutionException;
+
+/** Client for submitting a complete AgentPlan update to a running Flink Agents job. */
+public final class AgentPlanClient implements AutoCloseable {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String CLUSTER_ID = "flink-agents-plan-client";
+
+    private final RestClusterClient<String> restClient;
+
+    /** Creates a client for a JobManager REST host and port. */
+    public AgentPlanClient(String restAddress, int restPort) throws Exception {
+        this(new AgentRestClusterClient(createRestConfiguration(restAddress, restPort)));
+    }
+
+    /** Reflection entry point used by the Python client. */
+    private static AgentPlanClient create(String restAddress, Integer restPort) throws Exception {
+        Preconditions.checkNotNull(restPort, "REST port must not be null");
+        return new AgentPlanClient(restAddress, restPort);
+    }
+
+    @VisibleForTesting
+    AgentPlanClient(RestClusterClient<String> restClient) {
+        this.restClient = Preconditions.checkNotNull(restClient, "restClient must not be null");
+    }
+
+    private static Configuration createRestConfiguration(String restAddress, int restPort) {
+        Preconditions.checkArgument(
+                restAddress != null && !restAddress.trim().isEmpty(),
+                "REST address must not be blank");
+        Preconditions.checkArgument(
+                restPort > 0 && restPort <= 65535,
+                "REST port must be between 1 and 65535: %s",
+                restPort);
+        Configuration configuration = new Configuration();
+        configuration.set(RestOptions.ADDRESS, restAddress.trim());
+        configuration.set(RestOptions.PORT, restPort);
+        return configuration;
+    }
+
+    /** Serializes and submits a complete plan for the named deployed agent. */
+    public UpdateResult updateAgentPlan(JobID jobId, String agentName, AgentPlan agentPlan)
+            throws Exception {
+        Preconditions.checkNotNull(agentPlan, "agentPlan must not be null");
+        return updateAgentPlan(jobId, agentName, OBJECT_MAPPER.writeValueAsString(agentPlan));
+    }
+
+    /** Submits a complete plan JSON document for the named deployed agent. */
+    public UpdateResult updateAgentPlan(JobID jobId, String agentName, String agentPlanJson)
+            throws Exception {
+        Preconditions.checkNotNull(jobId, "jobId must not be null");
+        Preconditions.checkNotNull(agentPlanJson, "agentPlanJson must not be null");
+        String operatorUid = CompileUtils.getCoordinatedOperatorUid(agentName);
+        CoordinationResponse response;
+        try {
+            response =
+                    CoordinationRequestUtils.send(
+                                    restClient,
+                                    jobId,
+                                    operatorUid,
+                                    new PlanUpdateRequest(agentPlanJson))
+                            .get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } catch (ExecutionException e) {
+            throw unwrapExecutionException(e);
+        }
+        if (!(response instanceof PlanUpdateResponse)) {
+            throw new IllegalStateException(
+                    "Expected PlanUpdateResponse but received "
+                            + (response == null ? "null" : response.getClass().getName()));
+        }
+        PlanUpdateResponse planUpdateResponse = (PlanUpdateResponse) response;
+        return new UpdateResult(
+                planUpdateResponse.planVersion,
+                planUpdateResponse.planId,
+                planUpdateResponse.subtasksNotified);
+    }
+
+    /** String-only bridge used by Python's reflection helper. */
+    public UpdateResult updateAgentPlan(String jobId, String agentName, String agentPlanJson)
+            throws Exception {
+        Preconditions.checkNotNull(jobId, "jobId must not be null");
+        return updateAgentPlan(JobID.fromHexString(jobId), agentName, agentPlanJson);
+    }
+
+    private static Exception unwrapExecutionException(ExecutionException exception) {
+        Throwable cause = exception.getCause();
+        if (cause instanceof Exception) {
+            return (Exception) cause;
+        }
+        if (cause instanceof Error) {
+            throw (Error) cause;
+        }
+        return new RuntimeException(cause);
+    }
+
+    @Override
+    public void close() throws Exception {
+        restClient.close();
+    }
+
+    /**
+     * Confirmation that the current coordinator attempt accepted an update as a volatile candidate.
+     * It does not mean the update was announced, made durable, or activated.
+     */
+    public static final class UpdateResult {
+        private final long planVersion;
+        private final String planId;
+        private final int registeredSubtasks;
+
+        private UpdateResult(long planVersion, String planId, int registeredSubtasks) {
+            this.planVersion = planVersion;
+            this.planId = planId;
+            this.registeredSubtasks = registeredSubtasks;
+        }
+
+        public long getPlanVersion() {
+            return planVersion;
+        }
+
+        public String getPlanId() {
+            return planId;
+        }
+
+        /** Number of subtask gateways registered when the update was accepted. */
+        public int getRegisteredSubtasks() {
+            return registeredSubtasks;
+        }
+    }
+
+    /** Ensures coordination responses are deserialized with the Flink Agents classloader. */
+    private static final class AgentRestClusterClient extends RestClusterClient<String> {
+        private AgentRestClusterClient(Configuration configuration) throws Exception {
+            super(configuration, CLUSTER_ID);
+        }
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtils.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.client;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Flink-version-specific bridge for sending operator coordination requests. */
+final class CoordinationRequestUtils {
+
+    private CoordinationRequestUtils() {}
+
+    static CompletableFuture<CoordinationResponse> send(
+            RestClusterClient<?> restClient,
+            JobID jobId,
+            String operatorUid,
+            CoordinationRequest request) {
+        return restClient.sendCoordinationRequest(jobId, operatorUid, request);
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/env/RemoteExecutionEnvironment.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/env/RemoteExecutionEnvironment.java
@@ -133,6 +133,7 @@ public class RemoteExecutionEnvironment extends AgentsExecutionEnvironment {
         private final Map<String, Agent> agents;
 
         private AgentPlan agentPlan;
+        private String agentName;
         private DataStream<Object> outputDataStream;
 
         // Constructor for DataStream input
@@ -181,9 +182,21 @@ public class RemoteExecutionEnvironment extends AgentsExecutionEnvironment {
 
         @Override
         public AgentBuilder apply(Agent agent) {
+            String defaultName = agent.getClass().getSimpleName();
+            if (defaultName.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "An anonymous agent requires an explicit agent name via apply(name, agent).");
+            }
+            return apply(defaultName, agent);
+        }
+
+        @Override
+        public AgentBuilder apply(String agentName, Agent agent) {
+            CompileUtils.validateAgentName(agentName);
             try {
                 // Inspect resources registered in environment to agent.
                 agent.addResourcesIfAbsent(resources);
+                this.agentName = agentName;
                 this.agentPlan = new AgentPlan(agent, config);
                 return this;
             } catch (Exception e) {
@@ -201,7 +214,7 @@ public class RemoteExecutionEnvironment extends AgentsExecutionEnvironment {
                                 + "'; no agent with that name is registered on the environment. "
                                 + "Did you forget to call env.loadYaml(...) or env.getAgents().put(...) first?");
             }
-            return apply(agent);
+            return apply(agentName, agent);
         }
 
         @Override
@@ -219,11 +232,13 @@ public class RemoteExecutionEnvironment extends AgentsExecutionEnvironment {
             if (outputDataStream == null) {
                 if (keySelector != null) {
                     outputDataStream =
-                            CompileUtils.connectToAgent(inputDataStream, keySelector, agentPlan);
+                            CompileUtils.connectToAgent(
+                                    inputDataStream, keySelector, agentName, agentPlan);
                 } else {
                     // If no key selector provided, use a simple pass-through key selector
                     outputDataStream =
-                            CompileUtils.connectToAgent(inputDataStream, x -> x, agentPlan);
+                            CompileUtils.connectToAgent(
+                                    inputDataStream, x -> x, agentName, agentPlan);
                 }
             }
 

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/metrics/BuiltInMetrics.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/metrics/BuiltInMetrics.java
@@ -39,6 +39,8 @@ public class BuiltInMetrics {
 
     private final Counter eventLogTruncatedEvents;
 
+    private final Counter dynamicPlanUpdateRejected;
+
     private final HashMap<String, BuiltInActionMetrics> actionMetricGroups;
 
     public BuiltInMetrics(FlinkAgentsMetricGroupImpl parentMetricGroup, AgentPlan agentPlan) {
@@ -51,6 +53,8 @@ public class BuiltInMetrics {
                 parentMetricGroup.getMeter("numOfActionsExecutedPerSec", numOfActionsExecuted);
 
         this.eventLogTruncatedEvents = parentMetricGroup.getCounter("eventLogTruncatedEvents");
+
+        this.dynamicPlanUpdateRejected = parentMetricGroup.getCounter("dynamicPlanUpdateRejected");
 
         this.actionMetricGroups = new HashMap<>();
         for (String actionName : agentPlan.getActions().keySet()) {
@@ -72,6 +76,11 @@ public class BuiltInMetrics {
     public void markActionExecuted(String actionName) {
         numOfActionsExecutedPerSec.markEvent();
         actionMetricGroups.get(actionName).markActionExecuted();
+    }
+
+    /** Records a dynamic AgentPlan update that was rejected (e.g. malformed JSON, validation). */
+    public void markDynamicPlanUpdateRejected() {
+        dynamicPlanUpdateRejected.inc();
     }
 
     /** Returns the counter tracking event log truncation occurrences. */

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/metrics/BuiltInMetrics.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/metrics/BuiltInMetrics.java
@@ -43,7 +43,10 @@ public class BuiltInMetrics {
 
     private final HashMap<String, BuiltInActionMetrics> actionMetricGroups;
 
+    private final FlinkAgentsMetricGroupImpl parentMetricGroup;
+
     public BuiltInMetrics(FlinkAgentsMetricGroupImpl parentMetricGroup, AgentPlan agentPlan) {
+        this.parentMetricGroup = parentMetricGroup;
         Counter numOfEventsProcessed = parentMetricGroup.getCounter("numOfEventProcessed");
         this.numOfEventProcessedPerSec =
                 parentMetricGroup.getMeter("numOfEventProcessedPerSec", numOfEventsProcessed);
@@ -75,7 +78,13 @@ public class BuiltInMetrics {
      */
     public void markActionExecuted(String actionName) {
         numOfActionsExecutedPerSec.markEvent();
-        actionMetricGroups.get(actionName).markActionExecuted();
+        actionMetricGroups
+                .computeIfAbsent(
+                        actionName,
+                        name ->
+                                new BuiltInActionMetrics(
+                                        parentMetricGroup.getSubGroup("action", name)))
+                .markActionExecuted();
     }
 
     /** Records a dynamic AgentPlan update that was rejected (e.g. malformed JSON, validation). */

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -25,13 +25,12 @@ import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.agents.plan.PythonFunction;
 import org.apache.flink.agents.plan.actions.Action;
-import org.apache.flink.agents.runtime.ResourceCache;
 import org.apache.flink.agents.runtime.actionstate.ActionState;
 import org.apache.flink.agents.runtime.actionstate.ActionStateStore;
-import org.apache.flink.agents.runtime.memory.Mem0LongTermMemory;
 import org.apache.flink.agents.runtime.metrics.BuiltInMetrics;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
 import org.apache.flink.agents.runtime.python.operator.PythonActionTask;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.agents.runtime.utils.EventUtil;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.MailboxExecutor;
@@ -83,7 +82,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     private final AgentPlan agentPlan;
 
-    private transient ResourceCache resourceCache;
+    // Single plan-access entry: the live plan, the pending update waiting for the next checkpoint
+    // barrier, and their plan-scoped resource caches.
+    private transient PlanVersionManager planManager;
 
     private transient PythonBridgeManager pythonBridge;
 
@@ -95,9 +96,6 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     private transient ActionTaskContextManager contextManager;
 
-    // Long-term memory backed by Mem0; non-null only when LongTermMemoryOptions.Mem0 is configured.
-    private transient Mem0LongTermMemory ltm;
-
     // We need to check whether the current thread is the mailbox thread using the mailbox
     // processor.
     // TODO: This is a temporary workaround. In the future, we should add an interface in
@@ -106,6 +104,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     private transient MailboxProcessor mailboxProcessor;
 
     private final transient EventRouter<IN, OUT> eventRouter;
+
+    private final boolean inputIsJava;
 
     private final transient DurableExecutionManager durableExecManager;
 
@@ -127,6 +127,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         this.agentPlan = agentPlan;
         this.processingTimeService = processingTimeService;
         this.mailboxExecutor = mailboxExecutor;
+        this.inputIsJava = inputIsJava;
         this.eventRouter = new EventRouter<>(agentPlan, inputIsJava);
         this.durableExecManager = new DurableExecutionManager(actionStateStore);
         OperatorUtils.setChainStrategy(this, ChainingStrategy.ALWAYS);
@@ -144,34 +145,37 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     public void open() throws Exception {
         super.open();
 
-        stateManager.initializeKeyedStates(getRuntimeContext(), agentPlan.getConfig());
+        // From here on, everything plan-derived is built from the effective plan: the restored
+        // dynamic plan if the last checkpoint recorded a switch, otherwise the bootstrap plan.
+        // The effective plan always carries the bootstrap AgentConfiguration (job-level
+        // configuration is pinned at submission), so config reads below are stable across
+        // plan switches.
+        planManager.open(() -> getRuntimeContext().getUserCodeClassLoader());
+        AgentPlan effectivePlan = planManager.currentPlan();
+
+        stateManager.initializeKeyedStates(getRuntimeContext(), effectivePlan.getConfig());
         stateManager.initializeOperatorStates(getOperatorStateBackend());
 
-        // ResourceCache constructs its own long-lived ResourceContextImpl internally; on
-        // close() the cache cascades close to it and to the cached SkillManager, covering
-        // Flink failover when the JVM does not exit. The user-code class loader is threaded
-        // down so classpath: skill sources resolve against the Flink user JAR regardless of
-        // which thread (mailbox / Python interpreter / async pool) later triggers the lazy
-        // SkillManager construction.
-        resourceCache =
-                new ResourceCache(
-                        agentPlan.getResourceProviders(),
-                        getRuntimeContext().getUserCodeClassLoader());
-
         metricGroup = new FlinkAgentsMetricGroupImpl(getMetricGroup());
-        builtInMetrics = new BuiltInMetrics(metricGroup, agentPlan);
+        builtInMetrics = new BuiltInMetrics(metricGroup, effectivePlan);
 
         eventRouter.open(builtInMetrics);
 
-        durableExecManager.maybeInitActionStateStore(agentPlan.getConfig());
+        durableExecManager.maybeInitActionStateStore(effectivePlan.getConfig());
         durableExecManager.initRecoveryMarkerState(getOperatorStateBackend());
         durableExecManager.initializeKeyedStates(getRuntimeContext());
 
-        // init PythonActionExecutor and PythonResourceAdapter
-        pythonBridge = new PythonBridgeManager();
+        // init PythonActionExecutor and PythonResourceAdapter for the effective plan.
+        // ResourceCache (owned per plan by the PlanVersionManager) constructs its own long-lived
+        // ResourceContextImpl internally; on close() the cache cascades close to it and to the
+        // cached SkillManager, covering Flink failover when the JVM does not exit. The Flink
+        // user-code classloader is threaded down so classpath: skill sources resolve against the
+        // user JAR regardless of which thread (mailbox / Python interpreter / async pool) later
+        // triggers the lazy SkillManager construction.
+        pythonBridge = new PythonBridgeManager(!inputIsJava);
         pythonBridge.open(
-                agentPlan,
-                resourceCache,
+                effectivePlan,
+                planManager.currentResourceCache(),
                 getExecutionConfig(),
                 getRuntimeContext().getDistributedCache(),
                 getContainingTask().getEnvironment().getTaskManagerInfo().getTmpDirectories(),
@@ -181,14 +185,10 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                 jobIdentifier,
                 getRuntimeContext().getUserCodeClassLoader());
 
-        // Capture the wired Mem0 long-term memory, if any, so it can be plumbed into the Java
-        // runner context created by ActionTaskContextManager.
-        ltm = pythonBridge.getLongTermMemory();
-
         // init context manager for runner context creation and memory contexts
         contextManager =
                 new ActionTaskContextManager(
-                        agentPlan.getConfig().get(AgentExecutionOptions.NUM_ASYNC_THREADS));
+                        effectivePlan.getConfig().get(AgentExecutionOptions.NUM_ASYNC_THREADS));
 
         mailboxProcessor = getMailboxProcessor();
 
@@ -217,8 +217,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         LOG.debug("Receive an element {}", input);
 
         // wrap to InputEvent first
-        Event inputEvent =
-                eventRouter.wrapToInputEvent(input, pythonBridge.getPythonActionExecutor());
+        Event inputEvent = eventRouter.wrapToInputEvent(input, currentPythonActionExecutor());
         if (record.hasTimestamp()) {
             inputEvent.setSourceTimestamp(record.getTimestamp());
         }
@@ -247,8 +246,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         if (EventUtil.isOutputEvent(event)) {
             // If the event is an OutputEvent, we send it downstream.
             OUT outputData =
-                    eventRouter.getOutputFromOutputEvent(
-                            event, pythonBridge.getPythonActionExecutor());
+                    eventRouter.getOutputFromOutputEvent(event, currentPythonActionExecutor());
             if (event.hasSourceTimestamp()) {
                 output.collect(
                         eventRouter
@@ -266,7 +264,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             }
             // We then obtain the triggered action and add ActionTasks to the waiting processing
             // queue.
-            List<Action> triggerActions = eventRouter.getActionsTriggeredBy(event, agentPlan);
+            List<Action> triggerActions =
+                    eventRouter.getActionsTriggeredBy(event, planManager.currentPlan());
             if (triggerActions != null && !triggerActions.isEmpty()) {
                 for (Action triggerAction : triggerActions) {
                     stateManager.addActionTask(createActionTask(key, triggerAction, event));
@@ -319,15 +318,15 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         contextManager.createAndSetRunnerContext(
                 actionTask,
                 key,
-                agentPlan,
-                resourceCache,
+                planManager.currentPlan(),
+                planManager.currentResourceCache(),
                 metricGroup,
                 jobIdentifier,
                 this::checkMailboxThread,
                 stateManager.getSensoryMemState(),
                 stateManager.getShortTermMemState(),
                 pythonBridge.getPythonRunnerContext(),
-                ltm);
+                pythonBridge.getLongTermMemory());
 
         long sequenceNumber = stateManager.getSequenceNumber();
         boolean isFinished;
@@ -376,7 +375,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             ActionTask.ActionTaskResult actionTaskResult =
                     actionTask.invoke(
                             getRuntimeContext().getUserCodeClassLoader(),
-                            this.pythonBridge.getPythonActionExecutor());
+                            currentPythonActionExecutor());
 
             // We remove the contexts from the map after the task is processed. They will be added
             // back later if the action task has a generated action task, meaning it is not
@@ -468,24 +467,59 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
     @Override
     public void close() throws Exception {
-        // Must close before pythonInterpreter since cached resources may hold Python references.
-        if (resourceCache != null) {
-            resourceCache.close();
+        // Preserve the activation cleanup order: quiesce Python, release the Java runner context
+        // and plan resources while the interpreter is alive, then close Python itself.
+        Exception closeFailure = null;
+        try {
+            if (pythonBridge != null && planManager != null) {
+                pythonBridge.quiescePlan();
+            }
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
         }
-        if (contextManager != null) {
-            contextManager.close();
+        try {
+            if (contextManager != null) {
+                contextManager.close();
+            }
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
         }
-        if (pythonBridge != null) {
-            pythonBridge.close();
+        try {
+            if (planManager != null) {
+                planManager.close();
+            }
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
         }
-        if (eventRouter != null) {
-            eventRouter.close();
+        try {
+            if (pythonBridge != null) {
+                pythonBridge.close();
+            }
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
         }
-        if (durableExecManager != null) {
-            durableExecManager.close();
+        try {
+            if (eventRouter != null) {
+                eventRouter.close();
+            }
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
         }
-
-        super.close();
+        try {
+            if (durableExecManager != null) {
+                durableExecManager.close();
+            }
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
+        }
+        try {
+            super.close();
+        } catch (Exception e) {
+            closeFailure = ExceptionUtils.firstOrSuppressed(e, closeFailure);
+        }
+        if (closeFailure != null) {
+            throw closeFailure;
+        }
     }
 
     @Override
@@ -496,6 +530,11 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         durableExecManager.handleRecovery(getOperatorStateBackend());
 
         stateManager = new OperatorStateManager();
+
+        // Must run before open(): the effective plan (bootstrap or the restored dynamic plan)
+        // drives every plan-derived construction there.
+        planManager = new PlanVersionManager(agentPlan);
+        planManager.initializeState(getOperatorStateBackend(), context.isRestored());
 
         // Resolve the agent's stable job identifier:
         //  - If the user set it via AgentConfigOptions.JOB_IDENTIFIER, use that.
@@ -516,6 +555,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         durableExecManager.snapshotRecoveryMarker();
         durableExecManager.snapshotLastCompletedSequenceNumbers(
                 getKeyedStateBackend(), context.getCheckpointId());
+        planManager.snapshotState();
 
         super.snapshotState(context);
     }
@@ -530,6 +570,11 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     public void notifyCheckpointAborted(long checkpointId) throws Exception {
         durableExecManager.notifyCheckpointAborted(checkpointId);
         super.notifyCheckpointAborted(checkpointId);
+    }
+
+    /** The Python action executor of the live plan; null for pure-Java plans. */
+    private PythonActionExecutor currentPythonActionExecutor() {
+        return pythonBridge.getPythonActionExecutor();
     }
 
     private MailboxProcessor getMailboxProcessor() throws Exception {
@@ -602,6 +647,21 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     @VisibleForTesting
     OperatorStateManager getOperatorStateManager() {
         return stateManager;
+    }
+
+    @VisibleForTesting
+    AgentPlan getCurrentPlanForTesting() {
+        return planManager.currentPlan();
+    }
+
+    @VisibleForTesting
+    long getCurrentPlanVersionForTesting() {
+        return planManager.currentPlanVersion();
+    }
+
+    @VisibleForTesting
+    boolean hasPendingPlanForTesting() {
+        return planManager.hasPending();
     }
 
     /** Failed to execute Action task. */

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -35,6 +35,7 @@ import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.agents.runtime.utils.EventUtil;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -86,7 +87,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     private final AgentPlan agentPlan;
 
     // Single plan-access entry: the live plan, the pending update waiting for the next checkpoint
-    // barrier, and their plan-scoped resource caches.
+    // barrier, and their plan-scoped resources (classloader, resource cache).
     private transient PlanVersionManager planManager;
 
     private transient PythonBridgeManager pythonBridge;
@@ -121,6 +122,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     // Inspired by Apache Paimon.
     private transient String jobIdentifier;
 
+    private transient OperatorID operatorId;
+
     public ActionExecutionOperator(
             AgentPlan agentPlan,
             Boolean inputIsJava,
@@ -142,6 +145,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             StreamConfig config,
             Output<StreamRecord<OUT>> output) {
         super.setup(containingTask, config, output);
+        operatorId = config.getOperatorID();
     }
 
     @Override
@@ -172,9 +176,10 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         // init PythonActionExecutor and PythonResourceAdapter for the effective plan.
         // ResourceCache (owned per plan by the PlanVersionManager) constructs its own long-lived
         // ResourceContextImpl internally; on close() the cache cascades close to it and to the
-        // cached SkillManager, covering Flink failover when the JVM does not exit. The active
-        // plan classloader is threaded down so both job jars and a dynamic Java artifact remain
-        // visible from mailbox, Python interpreter and async-pool threads.
+        // cached SkillManager, covering Flink failover when the JVM does not exit. The plan
+        // classloader is threaded down so classpath: skill sources resolve against the plan's
+        // artifact (or the Flink user JAR) regardless of which thread (mailbox / Python
+        // interpreter / async pool) later triggers the lazy SkillManager construction.
         pythonBridge = new PythonBridgeManager(!inputIsJava);
         pythonBridge.open(
                 effectivePlan,
@@ -186,7 +191,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                 metricGroup,
                 this::checkMailboxThread,
                 jobIdentifier,
-                planManager.currentClassLoader());
+                planManager.currentClassLoader(),
+                operatorId.toHexString(),
+                planManager.currentPlanVersion());
 
         // init context manager for runner context creation and memory contexts
         contextManager =
@@ -470,7 +477,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     @Override
     public void close() throws Exception {
         // Preserve the activation cleanup order: quiesce Python, release the Java runner context
-        // and plan resources while the interpreter is alive, then close Python itself.
+        // and plan resources while the interpreter is alive, then retire/close Python itself.
         Exception closeFailure = null;
         try {
             if (pythonBridge != null && planManager != null) {
@@ -552,25 +559,21 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         }
     }
 
-    @Override
-    public void snapshotState(StateSnapshotContext context) throws Exception {
-        durableExecManager.snapshotRecoveryMarker();
-        durableExecManager.snapshotLastCompletedSequenceNumbers(
-                getKeyedStateBackend(), context.getCheckpointId());
-        planManager.snapshotState();
-
-        super.snapshotState(context);
-    }
-
     /**
-     * Activates a pending plan at the checkpoint barrier. The barrier first drains every event
-     * chain admitted under the old plan, then rebuilds all plan-scoped runtime objects and switches
-     * the live plan. The snapshot taken immediately afterwards therefore contains the new plan and
-     * no in-flight work from the old one.
+     * The plan-switch point. When a validated update is pending, the operator first drains every
+     * in-flight event chain (a closed admission set: the barrier already blocks new input, so only
+     * chains admitted before the barrier remain and all of them stay on the old plan), then swaps
+     * the plan in place. The snapshot taken right after therefore records the switched plan
+     * together with an empty in-flight set: data before the barrier ran entirely on the old plan,
+     * data after it runs on the new one, and a restore of this checkpoint resumes directly on the
+     * new plan.
      *
-     * <p>The drain is deliberately unbounded. A local timeout could make subtasks switch at
-     * different checkpoints; holding the barrier instead preserves the global checkpoint boundary
-     * and lets Flink's checkpoint timeout decide whether the attempt should fail.
+     * <p>The drain is deliberately unbounded: it holds the barrier until every in-flight chain
+     * finishes, so a slow chain (e.g. a long LLM call) makes the checkpoint slow — possibly past
+     * the checkpoint timeout, which is expected and must be budgeted in the user's checkpoint
+     * configuration. A local drain timeout that defers the switch was rejected: subtasks would
+     * switch at different checkpoints, and since input consumption resumes right after the barrier,
+     * the next attempt would most likely fail to drain as well, starving the switch indefinitely.
      */
     @Override
     public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
@@ -580,22 +583,28 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             AgentPlan previousPlan = planManager.currentPlan();
             AgentPlan nextPlan = planManager.pendingPlan();
 
-            // Verify the content-addressed artifact again after drain and immediately before
-            // dismantling the current runtime.
+            // Re-check immutable artifacts after drain and before dismantling V1. The deployment
+            // contract still requires content-addressed artifacts to remain immutable for the
+            // rest of this barrier operation.
             planManager.validatePendingJavaArtifact();
             pythonBridge.validatePythonPlanMetadata(nextPlan);
             pythonBridge.validatePythonPlanTransition(previousPlan, nextPlan);
 
             // Runner contexts and ResourceCache may hold Python references. Quiesce the Python
             // executor, release the Java context, close Java-side resources while the old
-            // interpreter is still alive, and only then construct the next runtime. No input can
-            // run in this interval because the checkpoint barrier is holding the task.
+            // interpreter is still alive, and only then release the old version namespace and
+            // construct the next runtime. Other subtasks may still lease that namespace, so the
+            // shared module graph is removed only after its final runtime closes. No input can run
+            // in this interval because the checkpoint barrier is holding this task.
             pythonBridge.quiescePlan();
             durableExecManager.checkNoInFlightActionContexts();
             contextManager.resetForPlanSwitch();
             planManager.closeCurrentResourcesForSwitch();
             pythonBridge.activatePlan(
-                    nextPlan, planManager.pendingResourceCache(), planManager.pendingClassLoader());
+                    nextPlan,
+                    planManager.pendingResourceCache(),
+                    planManager.pendingClassLoader(),
+                    planManager.pendingPlanVersion());
 
             planManager.switchToPending();
             durableExecManager.setActivePlanId(planManager.currentPlanId());
@@ -604,9 +613,14 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     }
 
     /**
-     * Receives and prepares a plan update on the mailbox thread. Duplicate and stale deliveries are
-     * ignored. A rejected candidate fails this attempt so every subtask recovers from the same
-     * completed checkpoint instead of continuing with different local candidates.
+     * Receives a plan update from the coordinator (mailbox thread). This path performs only
+     * process-independent preparation: wire/JSON validation, artifact digest checks, Java
+     * classloading and Python metadata checks. It deliberately does not create a Python interpreter
+     * or load user modules into a plan namespace; that happens after the next barrier drains the
+     * old plan. Newest wins: a newer update replaces an unswitched pending one. Duplicate and stale
+     * deliveries are no-ops. A rejected update cleans up its pending resources and fails this
+     * attempt; the coordinator promotes that task failure to global recovery so all subtasks return
+     * to the same completed checkpoint without retrying the volatile candidate.
      */
     @Override
     public void handleOperatorEvent(OperatorEvent evt) {
@@ -644,6 +658,16 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             }
             ExceptionUtils.rethrow(e);
         }
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        durableExecManager.snapshotRecoveryMarker();
+        durableExecManager.snapshotLastCompletedSequenceNumbers(
+                getKeyedStateBackend(), context.getCheckpointId());
+        planManager.snapshotState();
+
+        super.snapshotState(context);
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -29,11 +29,14 @@ import org.apache.flink.agents.runtime.actionstate.ActionState;
 import org.apache.flink.agents.runtime.actionstate.ActionStateStore;
 import org.apache.flink.agents.runtime.metrics.BuiltInMetrics;
 import org.apache.flink.agents.runtime.metrics.FlinkAgentsMetricGroupImpl;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateEvent;
 import org.apache.flink.agents.runtime.python.operator.PythonActionTask;
 import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.agents.runtime.utils.EventUtil;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -74,7 +77,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * and the resulting output event is collected for further processing.
  */
 public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT>
-        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
+        implements OneInputStreamOperator<IN, OUT>, BoundedOneInput, OperatorEventHandler {
 
     private static final long serialVersionUID = 1L;
 
@@ -558,6 +561,46 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         planManager.snapshotState();
 
         super.snapshotState(context);
+    }
+
+    /**
+     * Receives and prepares a plan update on the mailbox thread. Duplicate and stale deliveries are
+     * ignored. A rejected candidate fails this attempt so every subtask recovers from the same
+     * completed checkpoint instead of continuing with different local candidates.
+     */
+    @Override
+    public void handleOperatorEvent(OperatorEvent evt) {
+        checkState(
+                evt instanceof PlanUpdateEvent,
+                "Unexpected operator event: " + evt.getClass().getName());
+        PlanUpdateEvent event = (PlanUpdateEvent) evt;
+        if (!planManager.isNewerThanKnown(event.planVersion)) {
+            LOG.info(
+                    "Ignoring AgentPlan update with planVersion {} (already at planVersion {}).",
+                    event.planVersion,
+                    planManager.currentPlanVersion());
+            return;
+        }
+        try {
+            planManager.preparePending(event.planVersion, event.planId, event.canonicalPlanJson);
+            LOG.info(
+                    "Validated AgentPlan update with planVersion {}; activating at the next checkpoint barrier.",
+                    event.planVersion);
+        } catch (Exception e) {
+            builtInMetrics.markDynamicPlanUpdateRejected();
+            LOG.warn(
+                    "Rejected AgentPlan update with planVersion {}; failing the attempt so all "
+                            + "subtasks recover from the current plan (planVersion {}).",
+                    event.planVersion,
+                    planManager.currentPlanVersion(),
+                    e);
+            try {
+                planManager.discardPending();
+            } catch (Exception cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
+            ExceptionUtils.rethrow(e);
+        }
     }
 
     @Override

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -167,6 +167,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         durableExecManager.maybeInitActionStateStore(effectivePlan.getConfig());
         durableExecManager.initRecoveryMarkerState(getOperatorStateBackend());
         durableExecManager.initializeKeyedStates(getRuntimeContext());
+        durableExecManager.setActivePlanId(planManager.currentPlanId());
 
         // init PythonActionExecutor and PythonResourceAdapter for the effective plan.
         // ResourceCache (owned per plan by the PlanVersionManager) constructs its own long-lived
@@ -591,6 +592,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             pythonBridge.activatePlan(nextPlan, planManager.pendingResourceCache());
 
             planManager.switchToPending();
+            durableExecManager.setActivePlanId(planManager.currentPlanId());
         }
         super.prepareSnapshotPreBarrier(checkpointId);
     }
@@ -732,6 +734,11 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     @VisibleForTesting
     long getCurrentPlanVersionForTesting() {
         return planManager.currentPlanVersion();
+    }
+
+    @VisibleForTesting
+    String getCurrentPlanIdForTesting() {
+        return planManager.currentPlanId();
     }
 
     @VisibleForTesting

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -172,10 +172,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         // init PythonActionExecutor and PythonResourceAdapter for the effective plan.
         // ResourceCache (owned per plan by the PlanVersionManager) constructs its own long-lived
         // ResourceContextImpl internally; on close() the cache cascades close to it and to the
-        // cached SkillManager, covering Flink failover when the JVM does not exit. The Flink
-        // user-code classloader is threaded down so classpath: skill sources resolve against the
-        // user JAR regardless of which thread (mailbox / Python interpreter / async pool) later
-        // triggers the lazy SkillManager construction.
+        // cached SkillManager, covering Flink failover when the JVM does not exit. The active
+        // plan classloader is threaded down so both job jars and a dynamic Java artifact remain
+        // visible from mailbox, Python interpreter and async-pool threads.
         pythonBridge = new PythonBridgeManager(!inputIsJava);
         pythonBridge.open(
                 effectivePlan,
@@ -187,7 +186,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
                 metricGroup,
                 this::checkMailboxThread,
                 jobIdentifier,
-                getRuntimeContext().getUserCodeClassLoader());
+                planManager.currentClassLoader());
 
         // init context manager for runner context creation and memory contexts
         contextManager =
@@ -378,8 +377,7 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
             ActionTask.ActionTaskResult actionTaskResult =
                     actionTask.invoke(
-                            getRuntimeContext().getUserCodeClassLoader(),
-                            currentPythonActionExecutor());
+                            planManager.currentClassLoader(), currentPythonActionExecutor());
 
             // We remove the contexts from the map after the task is processed. They will be added
             // back later if the action task has a generated action task, meaning it is not
@@ -593,7 +591,8 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
             durableExecManager.checkNoInFlightActionContexts();
             contextManager.resetForPlanSwitch();
             planManager.closeCurrentResourcesForSwitch();
-            pythonBridge.activatePlan(nextPlan, planManager.pendingResourceCache());
+            pythonBridge.activatePlan(
+                    nextPlan, planManager.pendingResourceCache(), planManager.pendingClassLoader());
 
             planManager.switchToPending();
             durableExecManager.setActivePlanId(planManager.currentPlanId());

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -581,6 +581,10 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
 
             AgentPlan nextPlan = planManager.pendingPlan();
 
+            // Verify the content-addressed artifact again after drain and immediately before
+            // dismantling the current runtime.
+            planManager.validatePendingJavaArtifact();
+
             // Runner contexts and ResourceCache may hold Python references. Quiesce the Python
             // executor, release the Java context, close Java-side resources while the old
             // interpreter is still alive, and only then construct the next runtime. No input can

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -577,11 +577,14 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         if (planManager.hasPending()) {
             waitInFlightEventsFinished();
 
+            AgentPlan previousPlan = planManager.currentPlan();
             AgentPlan nextPlan = planManager.pendingPlan();
 
             // Verify the content-addressed artifact again after drain and immediately before
             // dismantling the current runtime.
             planManager.validatePendingJavaArtifact();
+            pythonBridge.validatePythonPlanMetadata(nextPlan);
+            pythonBridge.validatePythonPlanTransition(previousPlan, nextPlan);
 
             // Runner contexts and ResourceCache may hold Python references. Quiesce the Python
             // executor, release the Java context, close Java-side resources while the old
@@ -620,6 +623,9 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
         }
         try {
             planManager.preparePending(event.planVersion, event.planId, event.canonicalPlanJson);
+            pythonBridge.validatePythonPlanMetadata(planManager.pendingPlan());
+            pythonBridge.validatePythonPlanTransition(
+                    planManager.currentPlan(), planManager.pendingPlan());
             LOG.info(
                     "Validated AgentPlan update with planVersion {}; activating at the next checkpoint barrier.",
                     event.planVersion);

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperator.java
@@ -564,6 +564,38 @@ public class ActionExecutionOperator<IN, OUT> extends AbstractStreamOperator<OUT
     }
 
     /**
+     * Activates a pending plan at the checkpoint barrier. The barrier first drains every event
+     * chain admitted under the old plan, then rebuilds all plan-scoped runtime objects and switches
+     * the live plan. The snapshot taken immediately afterwards therefore contains the new plan and
+     * no in-flight work from the old one.
+     *
+     * <p>The drain is deliberately unbounded. A local timeout could make subtasks switch at
+     * different checkpoints; holding the barrier instead preserves the global checkpoint boundary
+     * and lets Flink's checkpoint timeout decide whether the attempt should fail.
+     */
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        if (planManager.hasPending()) {
+            waitInFlightEventsFinished();
+
+            AgentPlan nextPlan = planManager.pendingPlan();
+
+            // Runner contexts and ResourceCache may hold Python references. Quiesce the Python
+            // executor, release the Java context, close Java-side resources while the old
+            // interpreter is still alive, and only then construct the next runtime. No input can
+            // run in this interval because the checkpoint barrier is holding the task.
+            pythonBridge.quiescePlan();
+            durableExecManager.checkNoInFlightActionContexts();
+            contextManager.resetForPlanSwitch();
+            planManager.closeCurrentResourcesForSwitch();
+            pythonBridge.activatePlan(nextPlan, planManager.pendingResourceCache());
+
+            planManager.switchToPending();
+        }
+        super.prepareSnapshotPreBarrier(checkpointId);
+    }
+
+    /**
      * Receives and prepares a plan update on the mailbox thread. Duplicate and stale deliveries are
      * ignored. A rejected candidate fails this attempt so every subtask recovers from the same
      * completed checkpoint instead of continuing with different local candidates.

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManager.java
@@ -315,6 +315,30 @@ class ActionTaskContextManager implements AutoCloseable {
         pythonAwaitableRefs.remove(actionTask);
     }
 
+    /**
+     * Releases the plan-scoped Java runner context after the activation barrier drained all action
+     * chains. The continuation executor is job-scoped and remains available; the next Java action
+     * lazily creates a context bound to the new plan and its ResourceCache.
+     */
+    void resetForPlanSwitch() throws Exception {
+        org.apache.flink.util.Preconditions.checkState(
+                actionTaskMemoryContexts.isEmpty()
+                        && continuationContexts.isEmpty()
+                        && pythonAwaitableRefs.isEmpty(),
+                "Cannot switch AgentPlan while action-task contexts are still in flight.");
+        if (runnerContext != null) {
+            runnerContext.checkNoPendingEvents();
+            org.apache.flink.util.Preconditions.checkState(
+                    runnerContext.getDurableExecutionContext() == null,
+                    "Cannot switch AgentPlan while a durable execution context is still in flight.");
+            try {
+                runnerContext.close();
+            } finally {
+                runnerContext = null;
+            }
+        }
+    }
+
     @Override
     public void close() throws Exception {
         if (runnerContext != null) {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/CoordinatedActionExecutionOperatorFactory.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/CoordinatedActionExecutionOperatorFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator;
+
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.actionstate.ActionStateStore;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateCoordinator;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.CoordinatedOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/**
+ * Factory that wires an {@link ActionExecutionOperator} (with dynamic plan enabled) to a {@link
+ * PlanUpdateCoordinator}: it registers the operator as an event handler and provides the
+ * coordinator.
+ */
+public class CoordinatedActionExecutionOperatorFactory<IN, OUT>
+        extends AbstractStreamOperatorFactory<OUT>
+        implements CoordinatedOperatorFactory<OUT>, OneInputStreamOperatorFactory<IN, OUT> {
+
+    private final AgentPlan agentPlan;
+    private final Boolean inputIsJava;
+    private final ActionStateStore actionStateStore;
+
+    public CoordinatedActionExecutionOperatorFactory(AgentPlan agentPlan, Boolean inputIsJava) {
+        this(agentPlan, inputIsJava, null);
+    }
+
+    public CoordinatedActionExecutionOperatorFactory(
+            AgentPlan agentPlan, Boolean inputIsJava, ActionStateStore actionStateStore) {
+        this.agentPlan = agentPlan;
+        this.inputIsJava = inputIsJava;
+        this.actionStateStore = actionStateStore;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends StreamOperator<OUT>> T createStreamOperator(
+            StreamOperatorParameters<OUT> parameters) {
+        ActionExecutionOperator<IN, OUT> op =
+                new ActionExecutionOperator<>(
+                        agentPlan,
+                        inputIsJava,
+                        parameters.getProcessingTimeService(),
+                        parameters.getMailboxExecutor(),
+                        actionStateStore);
+        OperatorID operatorId = parameters.getStreamConfig().getOperatorID();
+        parameters.getOperatorEventDispatcher().registerEventHandler(operatorId, op);
+        op.setup(
+                parameters.getContainingTask(),
+                parameters.getStreamConfig(),
+                parameters.getOutput());
+        return (T) op;
+    }
+
+    @Override
+    public OperatorCoordinator.Provider getCoordinatorProvider(String name, OperatorID operatorId) {
+        return new PlanUpdateCoordinator.Provider(operatorId);
+    }
+
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return ActionExecutionOperator.class;
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
@@ -132,6 +132,17 @@ class DurableExecutionManager implements ActionStatePersister, AutoCloseable {
         return actionStateStore != null;
     }
 
+    /**
+     * Scopes durable action-state keys by the live plan's content identity so a replay never reuses
+     * results written by a different candidate. Called at open with the restored planId and again
+     * at every plan switch.
+     */
+    void setActivePlanId(String planId) {
+        if (actionStateStore != null) {
+            actionStateStore.setActivePlanId(planId);
+        }
+    }
+
     void initRecoveryMarkerState(OperatorStateBackend operatorStateBackend) throws Exception {
         if (actionStateStore != null) {
             recoveryMarkerOpState =

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/DurableExecutionManager.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import static org.apache.flink.agents.api.configuration.AgentConfigOptions.ACTION_STATE_STORE_BACKEND;
 import static org.apache.flink.agents.runtime.actionstate.ActionStateStore.BackendType.FLUSS;
 import static org.apache.flink.agents.runtime.actionstate.ActionStateStore.BackendType.KAFKA;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Owns the durable-execution side of {@link ActionExecutionOperator}: the optional {@link
@@ -449,6 +450,12 @@ class DurableExecutionManager implements ActionStatePersister, AutoCloseable {
 
     boolean hasDurableContext(ActionTask actionTask) {
         return actionTaskDurableContexts.containsKey(actionTask);
+    }
+
+    void checkNoInFlightActionContexts() {
+        checkState(
+                actionTaskDurableContexts.isEmpty(),
+                "Cannot switch AgentPlan while durable action contexts are still in flight.");
     }
 
     @VisibleForTesting

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -53,12 +53,12 @@ import static org.apache.flink.util.Preconditions.checkState;
  * {@code prepareSnapshotPreBarrier} after the operator drained its in-flight chains and activated
  * the pending runtime.
  *
- * <p>Checkpointed fact: the current {@code (version, canonicalPlanJson)} as union operator state,
- * one record per subtask. On restore every subtask picks the record with the highest planVersion,
- * so after rescale all subtasks converge on the same plan. An empty state means the job never
- * switched and runs the bootstrap plan from the job graph. The pending slot is deliberately not
- * checkpointed: global recovery discards the volatile update and restores only the completed active
- * plan.
+ * <p>Checkpointed fact: the current {@code (version, planId, canonicalPlanJson)} as union operator
+ * state, one record per subtask. On restore every subtask picks the record with the highest
+ * planVersion, so after rescale all subtasks converge on the same plan. An empty state means the
+ * job never switched and runs the bootstrap plan from the job graph. The pending slot is
+ * deliberately not checkpointed: global recovery discards the volatile update and restores only the
+ * completed active plan.
  */
 class PlanVersionManager {
 
@@ -79,7 +79,10 @@ class PlanVersionManager {
 
     PlanVersionManager(AgentPlan bootstrapPlan) {
         this.bootstrapPlan = bootstrapPlan;
-        this.current = new PlanSlot(0L, null, bootstrapPlan);
+        String bootstrapPlanJson = canonicalJsonOf(bootstrapPlan);
+        this.current =
+                new PlanSlot(
+                        0L, PlanIds.planIdOf(bootstrapPlanJson), bootstrapPlanJson, bootstrapPlan);
     }
 
     /**
@@ -101,23 +104,25 @@ class PlanVersionManager {
             }
         }
         if (newest != null) {
+            checkState(
+                    newest.planId != null && !newest.planId.isBlank(),
+                    "Restored dynamic AgentPlan state is missing planId.");
             AgentPlan plan = OBJECT_MAPPER.readValue(newest.canonicalPlanJson, AgentPlan.class);
-            current = new PlanSlot(newest.version, newest.canonicalPlanJson, plan);
+            current = new PlanSlot(newest.version, newest.planId, newest.canonicalPlanJson, plan);
             LOG.info(
                     "Restored dynamic AgentPlan with planVersion {} from checkpoint state.",
                     newest.version);
         }
     }
 
-    /**
-     * Writes the current {@code (version, json)}; a never-switched subtask keeps the state empty.
-     */
+    /** Writes the current plan record; a never-switched subtask keeps the state empty. */
     void snapshotState() throws Exception {
         currentPlanState.clear();
         if (current.version > 0) {
             currentPlanState.add(
                     OBJECT_MAPPER.writeValueAsString(
-                            new CurrentPlanRecord(current.version, current.canonicalPlanJson())));
+                            new CurrentPlanRecord(
+                                    current.version, current.planId, current.canonicalPlanJson)));
         }
     }
 
@@ -132,6 +137,10 @@ class PlanVersionManager {
 
     long currentPlanVersion() {
         return current.version;
+    }
+
+    String currentPlanId() {
+        return current.planId;
     }
 
     AgentPlan currentPlan() {
@@ -189,7 +198,7 @@ class PlanVersionManager {
         AgentPlan received = OBJECT_MAPPER.readValue(canonicalPlanJson, AgentPlan.class);
         AgentPlan effective = withBootstrapConfig(received);
 
-        PlanSlot prepared = new PlanSlot(version, canonicalJsonOf(effective), effective);
+        PlanSlot prepared = new PlanSlot(version, planId, canonicalJsonOf(effective), effective);
         try {
             validateJavaActionsExecutable(effective, userCodeClassLoader.get());
             prepared.resourceCache =
@@ -299,22 +308,17 @@ class PlanVersionManager {
     /** One plan version and the plan-scoped resources tied to it. */
     private static final class PlanSlot {
         final long version;
-        @Nullable private String canonicalPlanJson;
+        final String planId;
+        private final String canonicalPlanJson;
         final AgentPlan plan;
         @Nullable ResourceCache resourceCache;
 
-        PlanSlot(long version, @Nullable String canonicalPlanJson, AgentPlan plan) {
+        PlanSlot(long version, String planId, String canonicalPlanJson, AgentPlan plan) {
             this.version = version;
+            checkState(planId != null && !planId.isBlank(), "planId must not be empty.");
+            this.planId = planId;
             this.canonicalPlanJson = canonicalPlanJson;
             this.plan = plan;
-        }
-
-        /** Lazily computed for the bootstrap plan: only needed once a snapshot must persist it. */
-        String canonicalPlanJson() {
-            if (canonicalPlanJson == null) {
-                canonicalPlanJson = canonicalJsonOf(plan);
-            }
-            return canonicalPlanJson;
         }
 
         void close() throws Exception {
@@ -329,12 +333,14 @@ class PlanVersionManager {
     public static final class CurrentPlanRecord implements Serializable {
         private static final long serialVersionUID = 1L;
         public long version;
+        public String planId;
         public String canonicalPlanJson;
 
         public CurrentPlanRecord() {}
 
-        public CurrentPlanRecord(long version, String canonicalPlanJson) {
+        public CurrentPlanRecord(long version, String planId, String canonicalPlanJson) {
             this.version = version;
+            this.planId = planId;
             this.canonicalPlanJson = canonicalPlanJson;
         }
     }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -55,12 +55,12 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * <p>Lifecycle of an update: {@link #preparePending} runs at event arrival on the mailbox thread —
  * it verifies the wire signature, deserializes the plan, pins the job-level configuration of the
- * bootstrap plan (only artifact coordinates are plan-scoped), builds the plan-scoped artifact
- * classloader and proves every Java action loadable through it. Python runtime construction is
- * deliberately deferred until the activation barrier. Newest wins: preparing a newer update
- * discards an unswitched older pending. {@link #switchToPending} runs at {@code
- * prepareSnapshotPreBarrier} after the operator drained its in-flight chains and activated the
- * pending runtime.
+ * bootstrap plan (only the four Java/Python artifact path and sha256 keys are plan-scoped), builds
+ * the plan-scoped artifact classloader and proves every Java action loadable through it. Python
+ * runtime construction is deliberately deferred until the activation barrier because loading user
+ * modules may execute import-time code. Newest wins: preparing a newer update discards an
+ * unswitched older pending. {@link #switchToPending} runs at {@code prepareSnapshotPreBarrier}
+ * after the operator drained its in-flight chains and activated the pending runtime.
  *
  * <p>Checkpointed fact: the current {@code (version, planId, canonicalPlanJson)} as union operator
  * state, one record per subtask. On restore every subtask picks the record with the highest
@@ -149,7 +149,7 @@ class PlanVersionManager {
     /**
      * Late wiring of the user-code classloader (available only from {@code open()}). A restored
      * dynamic plan re-creates its artifact classloader here and re-proves that its Java action
-     * classes are loadable before it can run.
+     * classes are loadable — without its artifact the plan cannot run, so this fails fast.
      */
     void open(Supplier<ClassLoader> userCodeClassLoader) throws Exception {
         this.userCodeClassLoader = userCodeClassLoader;
@@ -193,6 +193,11 @@ class PlanVersionManager {
         return pending == null ? null : pending.plan;
     }
 
+    long pendingPlanVersion() {
+        checkState(pending != null, "No pending AgentPlan.");
+        return pending.version;
+    }
+
     @Nullable
     ResourceCache pendingResourceCache() {
         return pending == null ? null : pending.resourceCache;
@@ -226,7 +231,6 @@ class PlanVersionManager {
                 planId);
         AgentPlan received = OBJECT_MAPPER.readValue(canonicalPlanJson, AgentPlan.class);
         AgentPlan effective = withBootstrapConfig(received);
-        validateJavaArtifactMetadata(effective);
         validateJavaArtifactTransition(current.plan, effective);
 
         PlanSlot prepared = new PlanSlot(version, planId, canonicalJsonOf(effective), effective);
@@ -317,7 +321,7 @@ class PlanVersionManager {
     /**
      * Job-level configuration is pinned at submission: the effective plan keeps the update's
      * actions/routing/resources but carries the bootstrap {@code AgentConfiguration}, except for
-     * Java and Python artifact coordinates whose values belong to a specific plan version.
+     * the update's four Java/Python artifact path and sha256 keys, which are plan-scoped by nature.
      */
     private AgentPlan withBootstrapConfig(AgentPlan received) {
         Map<String, Object> merged = new HashMap<>(bootstrapPlan.getConfig().getConfData());

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -47,11 +48,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * <p>Lifecycle of an update: {@link #preparePending} runs at event arrival on the mailbox thread —
  * it verifies the wire signature, deserializes the plan, pins the job-level configuration of the
- * bootstrap plan, and proves every Java action loadable through the job's user-code classloader.
- * Python runtime construction is deliberately deferred until the activation barrier. Newest wins:
- * preparing a newer update discards an unswitched older pending. {@link #switchToPending} runs at
- * {@code prepareSnapshotPreBarrier} after the operator drained its in-flight chains and activated
- * the pending runtime.
+ * bootstrap plan (only artifact coordinates are plan-scoped), and proves every Java action loadable
+ * through the job's user-code classloader. Python runtime construction is deliberately deferred
+ * until the activation barrier. Newest wins: preparing a newer update discards an unswitched older
+ * pending. {@link #switchToPending} runs at {@code prepareSnapshotPreBarrier} after the operator
+ * drained its in-flight chains and activated the pending runtime.
  *
  * <p>Checkpointed fact: the current {@code (version, planId, canonicalPlanJson)} as union operator
  * state, one record per subtask. On restore every subtask picks the record with the highest
@@ -63,6 +64,13 @@ import static org.apache.flink.util.Preconditions.checkState;
 class PlanVersionManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(PlanVersionManager.class);
+
+    static final String JAVA_ARTIFACT_PATH_CONFIG = "dynamic-plan.java-artifact.path";
+    static final String JAVA_ARTIFACT_SHA256_CONFIG = "dynamic-plan.java-artifact.sha256";
+
+    /** Update-carried config keys honored during the bootstrap-config merge. */
+    private static final Set<String> PLAN_SCOPED_CONFIG_KEYS =
+            Set.of(JAVA_ARTIFACT_PATH_CONFIG, JAVA_ARTIFACT_SHA256_CONFIG);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -274,10 +282,20 @@ class PlanVersionManager {
 
     /**
      * Job-level configuration is pinned at submission: the effective plan keeps the update's
-     * actions/routing/resources but carries the bootstrap {@code AgentConfiguration}.
+     * actions/routing/resources but carries the bootstrap {@code AgentConfiguration}, except for
+     * artifact coordinates whose value belongs to a specific plan version.
      */
     private AgentPlan withBootstrapConfig(AgentPlan received) {
         Map<String, Object> merged = new HashMap<>(bootstrapPlan.getConfig().getConfData());
+        PLAN_SCOPED_CONFIG_KEYS.forEach(merged::remove);
+        received.getConfig()
+                .getConfData()
+                .forEach(
+                        (key, value) -> {
+                            if (PLAN_SCOPED_CONFIG_KEYS.contains(key)) {
+                                merged.put(key, value);
+                            }
+                        });
         return new AgentPlan(
                 received.getActions(),
                 received.getActionsByEvent(),

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -78,7 +78,11 @@ class PlanVersionManager {
 
     /** Update-carried config keys honored during the bootstrap-config merge. */
     private static final Set<String> PLAN_SCOPED_CONFIG_KEYS =
-            Set.of(JAVA_ARTIFACT_PATH_CONFIG, JAVA_ARTIFACT_SHA256_CONFIG);
+            Set.of(
+                    JAVA_ARTIFACT_PATH_CONFIG,
+                    JAVA_ARTIFACT_SHA256_CONFIG,
+                    PythonBridgeManager.PYTHON_ARTIFACT_PATH_CONFIG,
+                    PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -313,7 +317,7 @@ class PlanVersionManager {
     /**
      * Job-level configuration is pinned at submission: the effective plan keeps the update's
      * actions/routing/resources but carries the bootstrap {@code AgentConfiguration}, except for
-     * artifact coordinates whose value belongs to a specific plan version.
+     * Java and Python artifact coordinates whose values belong to a specific plan version.
      */
     private AgentPlan withBootstrapConfig(AgentPlan received) {
         Map<String, Object> merged = new HashMap<>(bootstrapPlan.getConfig().getConfData());

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -33,7 +33,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.Closeable;
 import java.io.Serializable;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -52,11 +55,12 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * <p>Lifecycle of an update: {@link #preparePending} runs at event arrival on the mailbox thread —
  * it verifies the wire signature, deserializes the plan, pins the job-level configuration of the
- * bootstrap plan (only artifact coordinates are plan-scoped), and proves every Java action loadable
- * through the job's user-code classloader. Python runtime construction is deliberately deferred
- * until the activation barrier. Newest wins: preparing a newer update discards an unswitched older
- * pending. {@link #switchToPending} runs at {@code prepareSnapshotPreBarrier} after the operator
- * drained its in-flight chains and activated the pending runtime.
+ * bootstrap plan (only artifact coordinates are plan-scoped), builds the plan-scoped artifact
+ * classloader and proves every Java action loadable through it. Python runtime construction is
+ * deliberately deferred until the activation barrier. Newest wins: preparing a newer update
+ * discards an unswitched older pending. {@link #switchToPending} runs at {@code
+ * prepareSnapshotPreBarrier} after the operator drained its in-flight chains and activated the
+ * pending runtime.
  *
  * <p>Checkpointed fact: the current {@code (version, planId, canonicalPlanJson)} as union operator
  * state, one record per subtask. On restore every subtask picks the record with the highest
@@ -140,11 +144,16 @@ class PlanVersionManager {
 
     /**
      * Late wiring of the user-code classloader (available only from {@code open()}). A restored
-     * dynamic plan re-proves that its Java actions are still loadable before it can run.
+     * dynamic plan re-creates its artifact classloader here and re-proves that its Java action
+     * classes are loadable before it can run.
      */
     void open(Supplier<ClassLoader> userCodeClassLoader) throws Exception {
         this.userCodeClassLoader = userCodeClassLoader;
-        validateJavaActionsExecutable(current.plan, userCodeClassLoader.get());
+        if (current.version > 0 && current.classLoader == null) {
+            current.classLoader = createArtifactClassLoader(current.plan);
+        }
+        validateJavaActionsExecutable(
+                current.plan, current.classLoaderOrDefault(userCodeClassLoader.get()));
     }
 
     long currentPlanVersion() {
@@ -160,14 +169,13 @@ class PlanVersionManager {
     }
 
     ClassLoader currentClassLoader() {
-        return userCodeClassLoader.get();
+        return current.classLoaderOrDefault(userCodeClassLoader.get());
     }
 
     ResourceCache currentResourceCache() {
         if (current.resourceCache == null) {
             current.resourceCache =
-                    new ResourceCache(
-                            current.plan.getResourceProviders(), userCodeClassLoader.get());
+                    new ResourceCache(current.plan.getResourceProviders(), currentClassLoader());
         }
         return current.resourceCache;
     }
@@ -184,6 +192,11 @@ class PlanVersionManager {
     @Nullable
     ResourceCache pendingResourceCache() {
         return pending == null ? null : pending.resourceCache;
+    }
+
+    ClassLoader pendingClassLoader() {
+        checkState(pending != null, "No pending AgentPlan.");
+        return pending.classLoaderOrDefault(userCodeClassLoader.get());
     }
 
     /** An update is relevant only if newer than both the live plan and the waiting pending. */
@@ -214,9 +227,13 @@ class PlanVersionManager {
 
         PlanSlot prepared = new PlanSlot(version, planId, canonicalJsonOf(effective), effective);
         try {
-            validateJavaActionsExecutable(effective, userCodeClassLoader.get());
+            prepared.classLoader = createArtifactClassLoader(effective);
+            validateJavaActionsExecutable(
+                    effective, prepared.classLoaderOrDefault(userCodeClassLoader.get()));
             prepared.resourceCache =
-                    new ResourceCache(effective.getResourceProviders(), userCodeClassLoader.get());
+                    new ResourceCache(
+                            effective.getResourceProviders(),
+                            prepared.classLoaderOrDefault(userCodeClassLoader.get()));
         } catch (Exception e) {
             prepared.close();
             throw e;
@@ -336,6 +353,18 @@ class PlanVersionManager {
         }
     }
 
+    @Nullable
+    private ClassLoader createArtifactClassLoader(AgentPlan plan) throws Exception {
+        validateJavaArtifactMetadata(plan);
+        String artifactPath = normalizedConfigValue(plan, JAVA_ARTIFACT_PATH_CONFIG);
+        if (artifactPath == null) {
+            return null;
+        }
+        Path path = Path.of(artifactPath);
+        return new PlanArtifactClassLoader(
+                new URL[] {path.toUri().toURL()}, userCodeClassLoader.get());
+    }
+
     private static void validateJavaArtifactMetadata(AgentPlan plan) throws Exception {
         String artifactPath = normalizedConfigValue(plan, JAVA_ARTIFACT_PATH_CONFIG);
         String expectedSha256 = normalizedConfigValue(plan, JAVA_ARTIFACT_SHA256_CONFIG);
@@ -412,6 +441,7 @@ class PlanVersionManager {
         final String planId;
         private final String canonicalPlanJson;
         final AgentPlan plan;
+        @Nullable ClassLoader classLoader;
         @Nullable ResourceCache resourceCache;
 
         PlanSlot(long version, String planId, String canonicalPlanJson, AgentPlan plan) {
@@ -422,10 +452,34 @@ class PlanVersionManager {
             this.plan = plan;
         }
 
+        ClassLoader classLoaderOrDefault(ClassLoader fallback) {
+            return classLoader != null ? classLoader : fallback;
+        }
+
         void close() throws Exception {
+            Exception firstException = null;
             if (resourceCache != null) {
-                resourceCache.close();
+                try {
+                    resourceCache.close();
+                } catch (Exception e) {
+                    firstException = e;
+                }
                 resourceCache = null;
+            }
+            if (classLoader instanceof Closeable) {
+                try {
+                    ((Closeable) classLoader).close();
+                } catch (Exception e) {
+                    if (firstException == null) {
+                        firstException = e;
+                    } else {
+                        firstException.addSuppressed(e);
+                    }
+                }
+                classLoader = null;
+            }
+            if (firstException != null) {
+                throw firstException;
             }
         }
     }
@@ -443,6 +497,48 @@ class PlanVersionManager {
             this.version = version;
             this.planId = planId;
             this.canonicalPlanJson = canonicalPlanJson;
+        }
+    }
+
+    private static final class PlanArtifactClassLoader extends URLClassLoader {
+        static {
+            registerAsParallelCapable();
+        }
+
+        private PlanArtifactClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded == null) {
+                    if (isParentFirstClass(name)) {
+                        loaded = super.loadClass(name, false);
+                    } else {
+                        try {
+                            loaded = findClass(name);
+                        } catch (ClassNotFoundException ignored) {
+                            loaded = super.loadClass(name, false);
+                        }
+                    }
+                }
+                if (resolve) {
+                    resolveClass(loaded);
+                }
+                return loaded;
+            }
+        }
+
+        private static boolean isParentFirstClass(String name) {
+            return name.startsWith("java.")
+                    || name.startsWith("javax.")
+                    || name.startsWith("jakarta.")
+                    || name.startsWith("sun.")
+                    || name.startsWith("com.sun.")
+                    || name.startsWith("org.apache.flink.")
+                    || name.startsWith("org.slf4j.");
         }
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -34,8 +34,12 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -205,6 +209,8 @@ class PlanVersionManager {
                 planId);
         AgentPlan received = OBJECT_MAPPER.readValue(canonicalPlanJson, AgentPlan.class);
         AgentPlan effective = withBootstrapConfig(received);
+        validateJavaArtifactMetadata(effective);
+        validateJavaArtifactTransition(current.plan, effective);
 
         PlanSlot prepared = new PlanSlot(version, planId, canonicalJsonOf(effective), effective);
         try {
@@ -216,6 +222,13 @@ class PlanVersionManager {
             throw e;
         }
         pending = prepared;
+    }
+
+    /** Re-validates the pending Java artifact at the last safe point before switching plans. */
+    void validatePendingJavaArtifact() throws Exception {
+        checkState(pending != null, "No pending AgentPlan to validate.");
+        validateJavaArtifactMetadata(pending.plan);
+        validateJavaArtifactTransition(current.plan, pending.plan);
     }
 
     /** Drops the pending plan and closes resources prepared for it. */
@@ -321,6 +334,76 @@ class PlanVersionManager {
                 Class.forName(function.getQualName(), false, classLoader);
             }
         }
+    }
+
+    private static void validateJavaArtifactMetadata(AgentPlan plan) throws Exception {
+        String artifactPath = normalizedConfigValue(plan, JAVA_ARTIFACT_PATH_CONFIG);
+        String expectedSha256 = normalizedConfigValue(plan, JAVA_ARTIFACT_SHA256_CONFIG);
+        checkState(
+                (artifactPath == null) == (expectedSha256 == null),
+                "%s and %s must be configured together.",
+                JAVA_ARTIFACT_PATH_CONFIG,
+                JAVA_ARTIFACT_SHA256_CONFIG);
+        if (artifactPath == null) {
+            return;
+        }
+
+        Path path = Path.of(artifactPath);
+        checkState(
+                Files.isRegularFile(path),
+                "Java artifact path %s is not a readable file.",
+                artifactPath);
+        checkState(
+                expectedSha256.matches("(?i)[0-9a-f]{64}"),
+                "%s must contain exactly 64 hexadecimal characters.",
+                JAVA_ARTIFACT_SHA256_CONFIG);
+        String actual = PlanIds.sha256HexOfFile(path);
+        checkState(
+                actual.equalsIgnoreCase(expectedSha256),
+                "Java artifact %s failed sha256 verification: expected %s but was %s.",
+                artifactPath,
+                expectedSha256,
+                actual);
+    }
+
+    private static void validateJavaArtifactTransition(AgentPlan currentPlan, AgentPlan newPlan) {
+        String currentArtifactPath = normalizedConfigValue(currentPlan, JAVA_ARTIFACT_PATH_CONFIG);
+        String newArtifactPath = normalizedConfigValue(newPlan, JAVA_ARTIFACT_PATH_CONFIG);
+        if (sameConfiguredPath(currentArtifactPath, newArtifactPath)) {
+            String currentSha = normalizedSha(currentPlan);
+            String newSha = normalizedSha(newPlan);
+            checkState(
+                    Objects.equals(currentSha, newSha),
+                    "%s is immutable; use a new path for a different digest: %s.",
+                    JAVA_ARTIFACT_PATH_CONFIG,
+                    currentArtifactPath);
+        }
+    }
+
+    private static boolean sameConfiguredPath(
+            @Nullable String currentPath, @Nullable String newPath) {
+        if (currentPath == null || newPath == null) {
+            return false;
+        }
+        try {
+            Path current = Path.of(currentPath).toAbsolutePath().normalize();
+            Path next = Path.of(newPath).toAbsolutePath().normalize();
+            return current.equals(next) || Files.isSameFile(current, next);
+        } catch (Exception ignored) {
+            return currentPath.equals(newPath);
+        }
+    }
+
+    @Nullable
+    private static String normalizedSha(AgentPlan plan) {
+        String sha = normalizedConfigValue(plan, JAVA_ARTIFACT_SHA256_CONFIG);
+        return sha == null ? null : sha.toLowerCase(Locale.ROOT);
+    }
+
+    @Nullable
+    private static String normalizedConfigValue(AgentPlan plan, String key) {
+        String configured = plan.getConfig().getStr(key, null);
+        return configured == null || configured.trim().isEmpty() ? null : configured.trim();
     }
 
     /** One plan version and the plan-scoped resources tied to it. */

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PlanVersionManager.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.plan.AgentConfiguration;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.ResourceCache;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanIds;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The single plan-access entry inside {@link ActionExecutionOperator} for checkpoint-aligned plan
+ * switching. At any point in time exactly one plan is live ({@code current}); at most one validated
+ * update waits for the next checkpoint barrier ({@code pending}).
+ *
+ * <p>Lifecycle of an update: {@link #preparePending} runs at event arrival on the mailbox thread —
+ * it verifies the wire signature, deserializes the plan, pins the job-level configuration of the
+ * bootstrap plan, and proves every Java action loadable through the job's user-code classloader.
+ * Python runtime construction is deliberately deferred until the activation barrier. Newest wins:
+ * preparing a newer update discards an unswitched older pending. {@link #switchToPending} runs at
+ * {@code prepareSnapshotPreBarrier} after the operator drained its in-flight chains and activated
+ * the pending runtime.
+ *
+ * <p>Checkpointed fact: the current {@code (version, canonicalPlanJson)} as union operator state,
+ * one record per subtask. On restore every subtask picks the record with the highest planVersion,
+ * so after rescale all subtasks converge on the same plan. An empty state means the job never
+ * switched and runs the bootstrap plan from the job graph. The pending slot is deliberately not
+ * checkpointed: global recovery discards the volatile update and restores only the completed active
+ * plan.
+ */
+class PlanVersionManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlanVersionManager.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final ListStateDescriptor<String> CURRENT_PLAN_STATE_DESCRIPTOR =
+            new ListStateDescriptor<>("dynamic-agent-plan-current", Types.STRING);
+
+    private final AgentPlan bootstrapPlan;
+
+    private PlanSlot current;
+    @Nullable private PlanSlot pending;
+
+    private Supplier<ClassLoader> userCodeClassLoader;
+    private ListState<String> currentPlanState;
+
+    PlanVersionManager(AgentPlan bootstrapPlan) {
+        this.bootstrapPlan = bootstrapPlan;
+        this.current = new PlanSlot(0L, null, bootstrapPlan);
+    }
+
+    /**
+     * Registers/restores the current-plan union state. Must run before {@link #open} and before the
+     * operator builds any plan-derived runtime, so {@code open()} sees the restored plan.
+     */
+    void initializeState(OperatorStateStore stateStore, boolean restored) throws Exception {
+        currentPlanState = stateStore.getUnionListState(CURRENT_PLAN_STATE_DESCRIPTOR);
+        if (!restored) {
+            return;
+        }
+        // Union state: every subtask sees all subtasks' records; the highest planVersion wins so
+        // all subtasks (including new ones after a rescale) converge on the same plan.
+        CurrentPlanRecord newest = null;
+        for (String record : currentPlanState.get()) {
+            CurrentPlanRecord r = OBJECT_MAPPER.readValue(record, CurrentPlanRecord.class);
+            if (newest == null || r.version > newest.version) {
+                newest = r;
+            }
+        }
+        if (newest != null) {
+            AgentPlan plan = OBJECT_MAPPER.readValue(newest.canonicalPlanJson, AgentPlan.class);
+            current = new PlanSlot(newest.version, newest.canonicalPlanJson, plan);
+            LOG.info(
+                    "Restored dynamic AgentPlan with planVersion {} from checkpoint state.",
+                    newest.version);
+        }
+    }
+
+    /**
+     * Writes the current {@code (version, json)}; a never-switched subtask keeps the state empty.
+     */
+    void snapshotState() throws Exception {
+        currentPlanState.clear();
+        if (current.version > 0) {
+            currentPlanState.add(
+                    OBJECT_MAPPER.writeValueAsString(
+                            new CurrentPlanRecord(current.version, current.canonicalPlanJson())));
+        }
+    }
+
+    /**
+     * Late wiring of the user-code classloader (available only from {@code open()}). A restored
+     * dynamic plan re-proves that its Java actions are still loadable before it can run.
+     */
+    void open(Supplier<ClassLoader> userCodeClassLoader) throws Exception {
+        this.userCodeClassLoader = userCodeClassLoader;
+        validateJavaActionsExecutable(current.plan, userCodeClassLoader.get());
+    }
+
+    long currentPlanVersion() {
+        return current.version;
+    }
+
+    AgentPlan currentPlan() {
+        return current.plan;
+    }
+
+    ClassLoader currentClassLoader() {
+        return userCodeClassLoader.get();
+    }
+
+    ResourceCache currentResourceCache() {
+        if (current.resourceCache == null) {
+            current.resourceCache =
+                    new ResourceCache(
+                            current.plan.getResourceProviders(), userCodeClassLoader.get());
+        }
+        return current.resourceCache;
+    }
+
+    boolean hasPending() {
+        return pending != null;
+    }
+
+    @Nullable
+    AgentPlan pendingPlan() {
+        return pending == null ? null : pending.plan;
+    }
+
+    @Nullable
+    ResourceCache pendingResourceCache() {
+        return pending == null ? null : pending.resourceCache;
+    }
+
+    /** An update is relevant only if newer than both the live plan and the waiting pending. */
+    boolean isNewerThanKnown(long version) {
+        return version > current.version && (pending == null || version > pending.version);
+    }
+
+    /**
+     * Validates and prepares an update as the pending plan, replacing (and closing) any older
+     * unswitched pending. Failures leave no pending plan and never disturb the current plan.
+     */
+    void preparePending(long version, String planId, String canonicalPlanJson) throws Exception {
+        checkState(
+                isNewerThanKnown(version),
+                "Update planVersion %s is not newer than the known plans.",
+                version);
+
+        discardPending();
+
+        checkState(
+                PlanIds.planIdOf(canonicalPlanJson).equals(planId),
+                "Received plan JSON does not match its planId %s.",
+                planId);
+        AgentPlan received = OBJECT_MAPPER.readValue(canonicalPlanJson, AgentPlan.class);
+        AgentPlan effective = withBootstrapConfig(received);
+
+        PlanSlot prepared = new PlanSlot(version, canonicalJsonOf(effective), effective);
+        try {
+            validateJavaActionsExecutable(effective, userCodeClassLoader.get());
+            prepared.resourceCache =
+                    new ResourceCache(effective.getResourceProviders(), userCodeClassLoader.get());
+        } catch (Exception e) {
+            prepared.close();
+            throw e;
+        }
+        pending = prepared;
+    }
+
+    /** Drops the pending plan and closes resources prepared for it. */
+    void discardPending() throws Exception {
+        if (pending == null) {
+            return;
+        }
+        PlanSlot discarded = pending;
+        pending = null;
+        discarded.close();
+    }
+
+    /**
+     * Swaps the pending plan in as the current one and closes the previous plan's resources. Must
+     * only be called after the operator drained all in-flight event chains, so nothing references
+     * the old plan anymore.
+     */
+    void switchToPending() throws Exception {
+        checkState(pending != null, "No pending AgentPlan to switch to.");
+        PlanSlot old = current;
+        current = pending;
+        pending = null;
+        old.close();
+        LOG.info(
+                "Switched AgentPlan from planVersion {} to planVersion {} at the checkpoint barrier.",
+                old.version,
+                current.version);
+    }
+
+    /**
+     * Releases live-plan Java resources after the barrier drain but before its Python interpreter
+     * is closed. The logical current plan is deliberately unchanged until the replacement runtime
+     * is ready. If later activation fails, the caller must fail the task rather than continue with
+     * this locally dismantled plan.
+     */
+    void closeCurrentResourcesForSwitch() throws Exception {
+        checkState(pending != null, "No pending AgentPlan to switch to.");
+        current.close();
+    }
+
+    void close() throws Exception {
+        Exception firstException = null;
+        try {
+            if (pending != null) {
+                pending.close();
+                pending = null;
+            }
+        } catch (Exception e) {
+            firstException = e;
+        }
+        try {
+            current.close();
+        } catch (Exception e) {
+            if (firstException == null) {
+                firstException = e;
+            } else {
+                firstException.addSuppressed(e);
+            }
+        }
+        if (firstException != null) {
+            throw firstException;
+        }
+    }
+
+    /**
+     * Job-level configuration is pinned at submission: the effective plan keeps the update's
+     * actions/routing/resources but carries the bootstrap {@code AgentConfiguration}.
+     */
+    private AgentPlan withBootstrapConfig(AgentPlan received) {
+        Map<String, Object> merged = new HashMap<>(bootstrapPlan.getConfig().getConfData());
+        return new AgentPlan(
+                received.getActions(),
+                received.getActionsByEvent(),
+                received.getResourceProviders(),
+                new AgentConfiguration(merged));
+    }
+
+    /** Canonical JSON of a plan object — the exact form persisted and restored. */
+    static String canonicalJsonOf(AgentPlan plan) {
+        try {
+            return PlanIds.canonicalize(OBJECT_MAPPER.writeValueAsString(plan));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize AgentPlan.", e);
+        }
+    }
+
+    /** Every Java action's class must be loadable through the plan's classloader. */
+    private static void validateJavaActionsExecutable(AgentPlan plan, ClassLoader classLoader)
+            throws Exception {
+        for (Action action : plan.getActions().values()) {
+            if (action.getExec() instanceof JavaFunction) {
+                JavaFunction function = (JavaFunction) action.getExec();
+                Class.forName(function.getQualName(), false, classLoader);
+            }
+        }
+    }
+
+    /** One plan version and the plan-scoped resources tied to it. */
+    private static final class PlanSlot {
+        final long version;
+        @Nullable private String canonicalPlanJson;
+        final AgentPlan plan;
+        @Nullable ResourceCache resourceCache;
+
+        PlanSlot(long version, @Nullable String canonicalPlanJson, AgentPlan plan) {
+            this.version = version;
+            this.canonicalPlanJson = canonicalPlanJson;
+            this.plan = plan;
+        }
+
+        /** Lazily computed for the bootstrap plan: only needed once a snapshot must persist it. */
+        String canonicalPlanJson() {
+            if (canonicalPlanJson == null) {
+                canonicalPlanJson = canonicalJsonOf(plan);
+            }
+            return canonicalPlanJson;
+        }
+
+        void close() throws Exception {
+            if (resourceCache != null) {
+                resourceCache.close();
+                resourceCache = null;
+            }
+        }
+    }
+
+    /** Checkpointed record: the plan the subtask was running when the barrier passed. */
+    public static final class CurrentPlanRecord implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public long version;
+        public String canonicalPlanJson;
+
+        public CurrentPlanRecord() {}
+
+        public CurrentPlanRecord(long version, String canonicalPlanJson) {
+            this.version = version;
+            this.canonicalPlanJson = canonicalPlanJson;
+        }
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
@@ -88,7 +88,6 @@ class PythonBridgeManager implements AutoCloseable {
     private FlinkAgentsMetricGroupImpl metricGroup;
     private Runnable mailboxThreadChecker;
     private String jobIdentifier;
-    private ClassLoader userCodeClassLoader;
 
     private boolean initialized;
 
@@ -121,9 +120,9 @@ class PythonBridgeManager implements AutoCloseable {
      * @param metricGroup the agent metric group, exposed to Python via the runner context.
      * @param mailboxThreadChecker hook used by the runner context to assert mailbox-thread access.
      * @param jobIdentifier the job identifier used to scope Python state.
-     * @param userCodeClassLoader the operator's user-code class loader, propagated to {@link
-     *     JavaResourceAdapter} so reflective Java tool resolution sees user jars added via {@code
-     *     env.add_jars(...)}.
+     * @param planClassLoader the effective plan class loader, propagated to {@link
+     *     JavaResourceAdapter} so reflective Java action and tool resolution sees both the job's
+     *     user jars and the current dynamic Java artifact.
      */
     void open(
             AgentPlan agentPlan,
@@ -135,7 +134,7 @@ class PythonBridgeManager implements AutoCloseable {
             FlinkAgentsMetricGroupImpl metricGroup,
             Runnable mailboxThreadChecker,
             String jobIdentifier,
-            ClassLoader userCodeClassLoader)
+            ClassLoader planClassLoader)
             throws Exception {
         this.executionConfig = executionConfig;
         this.distributedCache = distributedCache;
@@ -144,13 +143,13 @@ class PythonBridgeManager implements AutoCloseable {
         this.metricGroup = metricGroup;
         this.mailboxThreadChecker = mailboxThreadChecker;
         this.jobIdentifier = jobIdentifier;
-        this.userCodeClassLoader = userCodeClassLoader;
 
-        activeRuntime = createPlanRuntime(agentPlan, resourceCache);
+        activeRuntime = createPlanRuntime(agentPlan, resourceCache, planClassLoader);
     }
 
     @Nullable
-    private PlanPythonRuntime createPlanRuntime(AgentPlan agentPlan, ResourceCache resourceCache)
+    private PlanPythonRuntime createPlanRuntime(
+            AgentPlan agentPlan, ResourceCache resourceCache, ClassLoader planClassLoader)
             throws Exception {
         boolean containPythonAction = containsPythonAction(agentPlan);
         boolean containPythonResource = containsPythonResource(agentPlan);
@@ -172,7 +171,7 @@ class PythonBridgeManager implements AutoCloseable {
                             jobIdentifier);
             JavaResourceAdapter javaResourceAdapter =
                     new JavaResourceAdapter(
-                            resourceCache.getResourceContext(), interpreter, userCodeClassLoader);
+                            resourceCache.getResourceContext(), interpreter, planClassLoader);
 
             PythonResourceAdapterImpl pythonResourceAdapter = null;
             if (containPythonResource || mem0Configured) {
@@ -356,9 +355,11 @@ class PythonBridgeManager implements AutoCloseable {
      * <p>Any failure escapes the barrier. There is no local rollback after the old runtime has been
      * closed; the task must recover from the previous completed checkpoint.
      */
-    void activatePlan(AgentPlan newPlan, ResourceCache newResourceCache) throws Exception {
+    void activatePlan(
+            AgentPlan newPlan, ResourceCache newResourceCache, ClassLoader planClassLoader)
+            throws Exception {
         closeActiveRuntime();
-        activeRuntime = createPlanRuntime(newPlan, newResourceCache);
+        activeRuntime = createPlanRuntime(newPlan, newResourceCache, planClassLoader);
     }
 
     /** Stops old-plan async work before its interpreter and Java-side resources are released. */

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
@@ -43,7 +43,12 @@ import pemja.core.object.PyObject;
 
 import javax.annotation.Nullable;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.zip.ZipFile;
 
 import static org.apache.flink.agents.plan.actions.Utils.requiredVersions;
 import static org.apache.flink.agents.plan.actions.Utils.supportAsync;
@@ -76,6 +81,9 @@ import static org.apache.flink.agents.plan.actions.Utils.supportAsync;
 class PythonBridgeManager implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PythonBridgeManager.class);
+
+    static final String PYTHON_ARTIFACT_PATH_CONFIG = "dynamic-plan.python-artifact.path";
+    static final String PYTHON_ARTIFACT_SHA256_CONFIG = "dynamic-plan.python-artifact.sha256";
 
     private PythonEnvironmentManager pythonEnvironmentManager;
     @Nullable private PlanPythonRuntime activeRuntime;
@@ -144,6 +152,7 @@ class PythonBridgeManager implements AutoCloseable {
         this.mailboxThreadChecker = mailboxThreadChecker;
         this.jobIdentifier = jobIdentifier;
 
+        validatePythonPlanMetadata(agentPlan);
         activeRuntime = createPlanRuntime(agentPlan, resourceCache, planClassLoader);
     }
 
@@ -258,6 +267,109 @@ class PythonBridgeManager implements AutoCloseable {
                 || containsPythonAction(agentPlan)
                 || containsPythonResource(agentPlan)
                 || isMem0Configured(agentPlan);
+    }
+
+    /** Validates plan-scoped Python artifact metadata without starting or mutating CPython. */
+    void validatePythonPlanMetadata(AgentPlan agentPlan) throws Exception {
+        if (!needsPythonRuntime(agentPlan)) {
+            return;
+        }
+
+        String artifactPath = normalizedConfigValue(agentPlan, PYTHON_ARTIFACT_PATH_CONFIG);
+        String expectedSha256 = normalizedConfigValue(agentPlan, PYTHON_ARTIFACT_SHA256_CONFIG);
+        org.apache.flink.util.Preconditions.checkState(
+                (artifactPath == null) == (expectedSha256 == null),
+                "%s and %s must be configured together.",
+                PYTHON_ARTIFACT_PATH_CONFIG,
+                PYTHON_ARTIFACT_SHA256_CONFIG);
+        if (artifactPath == null) {
+            return;
+        }
+
+        Path path = Path.of(artifactPath);
+        org.apache.flink.util.Preconditions.checkState(
+                Files.isRegularFile(path),
+                "Python artifact path %s must be a regular file.",
+                artifactPath);
+        org.apache.flink.util.Preconditions.checkState(
+                expectedSha256.matches("(?i)[0-9a-f]{64}"),
+                "%s must contain exactly 64 hexadecimal characters.",
+                PYTHON_ARTIFACT_SHA256_CONFIG);
+        String actual =
+                org.apache.flink.agents.runtime.operator.coordinator.PlanIds.sha256HexOfFile(path);
+        org.apache.flink.util.Preconditions.checkState(
+                actual.equalsIgnoreCase(expectedSha256),
+                "Python artifact %s failed sha256 verification: expected %s but was %s.",
+                artifactPath,
+                expectedSha256,
+                actual);
+        try (ZipFile ignored = new ZipFile(path.toFile())) {
+            // Opening the archive validates its central directory without importing user code.
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Python artifact %s must be a valid zip or wheel archive.",
+                            artifactPath),
+                    e);
+        }
+    }
+
+    /** Rejects replacement of one Python artifact path with different contents. */
+    void validatePythonPlanTransition(AgentPlan currentPlan, AgentPlan newPlan) {
+        if (!needsPythonRuntime(currentPlan) && !needsPythonRuntime(newPlan)) {
+            return;
+        }
+
+        String currentArtifactPath =
+                normalizedConfiguredPath(currentPlan, PYTHON_ARTIFACT_PATH_CONFIG);
+        String newArtifactPath = normalizedConfiguredPath(newPlan, PYTHON_ARTIFACT_PATH_CONFIG);
+        if (sameConfiguredPath(currentArtifactPath, newArtifactPath)) {
+            String currentSha = normalizedSha(currentPlan);
+            String newSha = normalizedSha(newPlan);
+            org.apache.flink.util.Preconditions.checkState(
+                    Objects.equals(currentSha, newSha),
+                    "%s is immutable; use a new path for a different digest: %s.",
+                    PYTHON_ARTIFACT_PATH_CONFIG,
+                    currentArtifactPath);
+        }
+    }
+
+    @Nullable
+    private static String normalizedConfiguredPath(AgentPlan plan, String key) {
+        String configured = normalizedConfigValue(plan, key);
+        if (configured == null) {
+            return null;
+        }
+        Path path = Path.of(configured);
+        try {
+            return path.toRealPath().toString();
+        } catch (Exception ignored) {
+            return path.toAbsolutePath().normalize().toString();
+        }
+    }
+
+    private static boolean sameConfiguredPath(
+            @Nullable String currentPath, @Nullable String newPath) {
+        if (currentPath == null || newPath == null) {
+            return false;
+        }
+        try {
+            return Files.isSameFile(Path.of(currentPath), Path.of(newPath));
+        } catch (Exception ignored) {
+            return currentPath.equals(newPath);
+        }
+    }
+
+    @Nullable
+    private static String normalizedSha(AgentPlan plan) {
+        String sha = normalizedConfigValue(plan, PYTHON_ARTIFACT_SHA256_CONFIG);
+        return sha == null ? null : sha.toLowerCase(Locale.ROOT);
+    }
+
+    @Nullable
+    private static String normalizedConfigValue(AgentPlan plan, String key) {
+        String configured = plan.getConfig().getStr(key, null);
+        return configured == null || configured.trim().isEmpty() ? null : configured.trim();
     }
 
     /**

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
@@ -39,6 +39,7 @@ import org.apache.flink.python.env.PythonDependencyInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pemja.core.PythonInterpreter;
+import pemja.core.PythonInterpreterConfig;
 import pemja.core.object.PyObject;
 
 import javax.annotation.Nullable;
@@ -69,10 +70,12 @@ import static org.apache.flink.agents.plan.actions.Utils.supportAsync;
  *
  * <p>Lifecycle: instantiated by the operator's {@code open()} (lazy — not in the operator
  * constructor), then initialized via {@link #open}. At most one plan runtime is executable in the
- * process: after the activation barrier drains the old plan, {@link #activatePlan} closes its
- * interpreter and constructs the replacement. A Java-only plan still has a runtime when the
- * surrounding pipeline uses Python wire encoding, because input/output conversion runs in Python.
- * {@link #close()} closes the active interpreter and the shared environment manager.
+ * process: an update only receives static metadata validation on event arrival; after the
+ * activation barrier drains the old plan, {@link #activatePlan} quiesces and releases its versioned
+ * module namespace, closes its interpreter, and constructs the replacement. A Java-only plan still
+ * has a runtime when the surrounding pipeline uses Python wire encoding, because input/output
+ * conversion runs in Python. {@link #close()} releases the active module namespace before closing
+ * its interpreter and the shared environment manager.
  *
  * <p>Design constraint: package-private; no manager-to-manager held references. Other managers
  * receive what they need (e.g. the Python runner context, the action executor) via method
@@ -84,6 +87,11 @@ class PythonBridgeManager implements AutoCloseable {
 
     static final String PYTHON_ARTIFACT_PATH_CONFIG = "dynamic-plan.python-artifact.path";
     static final String PYTHON_ARTIFACT_SHA256_CONFIG = "dynamic-plan.python-artifact.sha256";
+    static final String PYTHON_RUNTIME_PATH_CONFIG = "dynamic-plan.python-runtime.path";
+
+    private static final String PLAN_FUNCTION_MODULE = "__fa_plan_function";
+    private static final String ACQUIRE_PYTHON_MODULE_NAMESPACE = "acquire_python_module_namespace";
+    private static final String RELEASE_PYTHON_MODULE_NAMESPACE = "release_python_module_namespace";
 
     private PythonEnvironmentManager pythonEnvironmentManager;
     @Nullable private PlanPythonRuntime activeRuntime;
@@ -96,7 +104,7 @@ class PythonBridgeManager implements AutoCloseable {
     private FlinkAgentsMetricGroupImpl metricGroup;
     private Runnable mailboxThreadChecker;
     private String jobIdentifier;
-
+    private String operatorIdentifier;
     private boolean initialized;
 
     PythonBridgeManager() {
@@ -142,7 +150,9 @@ class PythonBridgeManager implements AutoCloseable {
             FlinkAgentsMetricGroupImpl metricGroup,
             Runnable mailboxThreadChecker,
             String jobIdentifier,
-            ClassLoader planClassLoader)
+            ClassLoader planClassLoader,
+            String operatorIdentifier,
+            long planVersion)
             throws Exception {
         this.executionConfig = executionConfig;
         this.distributedCache = distributedCache;
@@ -151,14 +161,18 @@ class PythonBridgeManager implements AutoCloseable {
         this.metricGroup = metricGroup;
         this.mailboxThreadChecker = mailboxThreadChecker;
         this.jobIdentifier = jobIdentifier;
+        this.operatorIdentifier = operatorIdentifier;
 
         validatePythonPlanMetadata(agentPlan);
-        activeRuntime = createPlanRuntime(agentPlan, resourceCache, planClassLoader);
+        activeRuntime = createPlanRuntime(agentPlan, resourceCache, planClassLoader, planVersion);
     }
 
     @Nullable
     private PlanPythonRuntime createPlanRuntime(
-            AgentPlan agentPlan, ResourceCache resourceCache, ClassLoader planClassLoader)
+            AgentPlan agentPlan,
+            ResourceCache resourceCache,
+            ClassLoader planClassLoader,
+            long planVersion)
             throws Exception {
         boolean containPythonAction = containsPythonAction(agentPlan);
         boolean containPythonResource = containsPythonResource(agentPlan);
@@ -168,9 +182,21 @@ class PythonBridgeManager implements AutoCloseable {
             return null;
         }
 
-        PythonInterpreter interpreter = createPythonInterpreter();
+        PythonInterpreter interpreter = createPythonInterpreter(agentPlan);
         PythonActionExecutor pythonActionExecutor = null;
+        String artifactPath = pythonArtifactPath(agentPlan);
+        String moduleNamespace =
+                artifactPath == null
+                        ? null
+                        : pythonModuleNamespace(jobId, operatorIdentifier, planVersion);
+        boolean namespaceAcquired = false;
         try {
+            initializePlanFunctionModule(interpreter);
+            if (moduleNamespace != null) {
+                acquirePythonModuleNamespace(interpreter, moduleNamespace, artifactPath);
+                namespaceAcquired = true;
+            }
+
             PythonRunnerContextImpl pythonRunnerContext =
                     new PythonRunnerContextImpl(
                             metricGroup,
@@ -186,13 +212,21 @@ class PythonBridgeManager implements AutoCloseable {
             if (containPythonResource || mem0Configured) {
                 pythonResourceAdapter =
                         initPythonResourceAdapter(
-                                agentPlan, resourceCache, javaResourceAdapter, interpreter);
+                                agentPlan,
+                                resourceCache,
+                                javaResourceAdapter,
+                                interpreter,
+                                moduleNamespace);
             }
 
             if (containPythonAction || mem0Configured || pythonWireFormat) {
                 pythonActionExecutor =
                         initPythonActionExecutor(
-                                agentPlan, javaResourceAdapter, pythonRunnerContext, interpreter);
+                                agentPlan,
+                                javaResourceAdapter,
+                                pythonRunnerContext,
+                                interpreter,
+                                moduleNamespace);
             }
 
             Mem0LongTermMemory longTermMemory = null;
@@ -208,13 +242,21 @@ class PythonBridgeManager implements AutoCloseable {
                     pythonResourceAdapter,
                     javaResourceAdapter,
                     longTermMemory,
-                    interpreter);
+                    interpreter,
+                    moduleNamespace);
         } catch (Exception creationFailure) {
             if (pythonActionExecutor != null) {
                 try {
                     pythonActionExecutor.close();
                 } catch (Exception closeFailure) {
                     creationFailure.addSuppressed(closeFailure);
+                }
+            }
+            if (namespaceAcquired) {
+                try {
+                    releasePythonModuleNamespace(interpreter, moduleNamespace);
+                } catch (Exception cleanupFailure) {
+                    creationFailure.addSuppressed(cleanupFailure);
                 }
             }
             try {
@@ -226,53 +268,18 @@ class PythonBridgeManager implements AutoCloseable {
         }
     }
 
-    private PythonInterpreter createPythonInterpreter() throws Exception {
-        ensurePythonEnvironment();
-        EmbeddedPythonEnvironment env = pythonEnvironmentManager.createEnvironment();
-        return env.getInterpreter();
-    }
-
-    private void ensurePythonEnvironment() throws Exception {
-        if (initialized) {
-            return;
-        }
-        LOG.debug("Begin initialize PythonEnvironmentManager.");
-        PythonDependencyInfo dependencyInfo =
-                PythonDependencyInfo.create(executionConfig.toConfiguration(), distributedCache);
-        pythonEnvironmentManager =
-                new PythonEnvironmentManager(
-                        dependencyInfo, tmpDirs, new HashMap<>(System.getenv()), jobId);
-        pythonEnvironmentManager.open();
-        initialized = true;
-    }
-
-    private boolean containsPythonAction(AgentPlan agentPlan) {
-        return agentPlan.getActions().values().stream()
-                .anyMatch(action -> action.getExec() instanceof PythonFunction);
-    }
-
-    private boolean containsPythonResource(AgentPlan agentPlan) {
-        return agentPlan.getResourceProviders().values().stream()
-                .anyMatch(
-                        resourceProviderMap ->
-                                resourceProviderMap.values().stream()
-                                        .anyMatch(
-                                                resourceProvider ->
-                                                        resourceProvider
-                                                                instanceof PythonResourceProvider));
-    }
-
-    private boolean needsPythonRuntime(AgentPlan agentPlan) {
-        return pythonWireFormat
-                || containsPythonAction(agentPlan)
-                || containsPythonResource(agentPlan)
-                || isMem0Configured(agentPlan);
-    }
-
-    /** Validates plan-scoped Python artifact metadata without starting or mutating CPython. */
+    /** Validates plan-scoped Python paths without starting or mutating CPython. */
     void validatePythonPlanMetadata(AgentPlan agentPlan) throws Exception {
         if (!needsPythonRuntime(agentPlan)) {
             return;
+        }
+
+        String runtimePath = normalizedConfigValue(agentPlan, PYTHON_RUNTIME_PATH_CONFIG);
+        if (runtimePath != null) {
+            org.apache.flink.util.Preconditions.checkState(
+                    Files.exists(Path.of(runtimePath)),
+                    "Python runtime path %s does not exist.",
+                    runtimePath);
         }
 
         String artifactPath = normalizedConfigValue(agentPlan, PYTHON_ARTIFACT_PATH_CONFIG);
@@ -304,7 +311,7 @@ class PythonBridgeManager implements AutoCloseable {
                 expectedSha256,
                 actual);
         try (ZipFile ignored = new ZipFile(path.toFile())) {
-            // Opening the archive validates its central directory without importing user code.
+            // Opening the archive is enough to reject malformed zip/whl files before CPython.
         } catch (Exception e) {
             throw new IllegalStateException(
                     String.format(
@@ -314,11 +321,21 @@ class PythonBridgeManager implements AutoCloseable {
         }
     }
 
-    /** Rejects replacement of one Python artifact path with different contents. */
+    /** Validates immutable artifact and runtime-path boundaries for one running task. */
     void validatePythonPlanTransition(AgentPlan currentPlan, AgentPlan newPlan) {
         if (!needsPythonRuntime(currentPlan) && !needsPythonRuntime(newPlan)) {
             return;
         }
+
+        String currentRuntimePath =
+                normalizedConfiguredPath(currentPlan, PYTHON_RUNTIME_PATH_CONFIG);
+        String newRuntimePath = normalizedConfiguredPath(newPlan, PYTHON_RUNTIME_PATH_CONFIG);
+        org.apache.flink.util.Preconditions.checkState(
+                Objects.equals(currentRuntimePath, newRuntimePath),
+                "%s is job-level and cannot change while an AgentPlan job is running: %s -> %s.",
+                PYTHON_RUNTIME_PATH_CONFIG,
+                currentRuntimePath,
+                newRuntimePath);
 
         String currentArtifactPath =
                 normalizedConfiguredPath(currentPlan, PYTHON_ARTIFACT_PATH_CONFIG);
@@ -370,6 +387,71 @@ class PythonBridgeManager implements AutoCloseable {
     private static String normalizedConfigValue(AgentPlan plan, String key) {
         String configured = plan.getConfig().getStr(key, null);
         return configured == null || configured.trim().isEmpty() ? null : configured.trim();
+    }
+
+    private PythonInterpreter createPythonInterpreter(AgentPlan agentPlan) throws Exception {
+        ensurePythonEnvironment();
+        EmbeddedPythonEnvironment env = pythonEnvironmentManager.createEnvironment();
+        PythonInterpreterConfig baseConfig = env.getConfig();
+        PythonInterpreterConfig.PythonInterpreterConfigBuilder builder =
+                PythonInterpreterConfig.newBuilder().setExcType(baseConfig.getExecType());
+
+        String runtimePath = agentPlan.getConfig().getStr(PYTHON_RUNTIME_PATH_CONFIG, null);
+        if (runtimePath != null && !runtimePath.trim().isEmpty()) {
+            Path path = Path.of(runtimePath);
+            org.apache.flink.util.Preconditions.checkState(
+                    Files.exists(path), "Python runtime path %s does not exist.", runtimePath);
+            builder.addPythonPaths(path.toString());
+        }
+
+        builder.addPythonPaths(baseConfig.getPaths());
+        if (baseConfig.getPythonHome() != null) {
+            builder.setPythonHome(baseConfig.getPythonHome());
+        }
+        if (baseConfig.getWorkingDirectory() != null) {
+            builder.setWorkingDirectory(baseConfig.getWorkingDirectory());
+        }
+        if (baseConfig.getPythonExec() != null) {
+            builder.setPythonExec(baseConfig.getPythonExec());
+        }
+        return new PythonInterpreter(builder.build());
+    }
+
+    private void ensurePythonEnvironment() throws Exception {
+        if (initialized) {
+            return;
+        }
+        LOG.debug("Begin initialize PythonEnvironmentManager.");
+        PythonDependencyInfo dependencyInfo =
+                PythonDependencyInfo.create(executionConfig.toConfiguration(), distributedCache);
+        pythonEnvironmentManager =
+                new PythonEnvironmentManager(
+                        dependencyInfo, tmpDirs, new HashMap<>(System.getenv()), jobId);
+        pythonEnvironmentManager.open();
+        initialized = true;
+    }
+
+    private boolean containsPythonAction(AgentPlan agentPlan) {
+        return agentPlan.getActions().values().stream()
+                .anyMatch(action -> action.getExec() instanceof PythonFunction);
+    }
+
+    private boolean containsPythonResource(AgentPlan agentPlan) {
+        return agentPlan.getResourceProviders().values().stream()
+                .anyMatch(
+                        resourceProviderMap ->
+                                resourceProviderMap.values().stream()
+                                        .anyMatch(
+                                                resourceProvider ->
+                                                        resourceProvider
+                                                                instanceof PythonResourceProvider));
+    }
+
+    private boolean needsPythonRuntime(AgentPlan agentPlan) {
+        return pythonWireFormat
+                || containsPythonAction(agentPlan)
+                || containsPythonResource(agentPlan)
+                || isMem0Configured(agentPlan);
     }
 
     /**
@@ -437,7 +519,8 @@ class PythonBridgeManager implements AutoCloseable {
             AgentPlan agentPlan,
             JavaResourceAdapter javaResourceAdapter,
             PythonRunnerContextImpl pythonRunnerContext,
-            PythonInterpreter interpreter)
+            PythonInterpreter interpreter,
+            @Nullable String moduleNamespace)
             throws Exception {
         PythonActionExecutor pythonActionExecutor =
                 new PythonActionExecutor(
@@ -445,7 +528,8 @@ class PythonBridgeManager implements AutoCloseable {
                         agentPlan,
                         javaResourceAdapter,
                         pythonRunnerContext,
-                        jobIdentifier);
+                        jobIdentifier,
+                        moduleNamespace);
         try {
             pythonActionExecutor.open();
             return pythonActionExecutor;
@@ -459,37 +543,71 @@ class PythonBridgeManager implements AutoCloseable {
         }
     }
 
+    private static void initializePlanFunctionModule(PythonInterpreter interpreter) {
+        interpreter.exec(
+                "from flink_agents.plan import function as " + PLAN_FUNCTION_MODULE + "\n");
+    }
+
+    private static void acquirePythonModuleNamespace(
+            PythonInterpreter interpreter, String namespace, String artifactPath) {
+        interpreter.invokeMethod(
+                PLAN_FUNCTION_MODULE, ACQUIRE_PYTHON_MODULE_NAMESPACE, namespace, artifactPath);
+    }
+
+    private static void releasePythonModuleNamespace(
+            PythonInterpreter interpreter, String namespace) {
+        interpreter.invokeMethod(PLAN_FUNCTION_MODULE, RELEASE_PYTHON_MODULE_NAMESPACE, namespace);
+    }
+
+    static String pythonModuleNamespace(JobID jobId, String operatorIdentifier, long planVersion) {
+        return String.format(
+                "__fa_%s_%s_v%d", jobId.toHexString(), operatorIdentifier, planVersion);
+    }
+
     /**
-     * Rebuilds the Python-visible runtime while the checkpoint barrier still blocks input. The old
-     * runtime is quiesced and closed before the replacement is constructed and its declared Python
-     * action entries are resolved.
+     * Performs the Python-visible switch while the checkpoint barrier still blocks input. The old
+     * runtime is quiesced first and releases its lease on the old version namespace. The namespace
+     * is removed only when no co-located runtime still uses that version. The new runtime then
+     * acquires its version namespace and resolves the declared Python action entries inside it.
      *
      * <p>Any failure escapes the barrier. There is no local rollback after the old runtime has been
      * closed; the task must recover from the previous completed checkpoint.
      */
     void activatePlan(
-            AgentPlan newPlan, ResourceCache newResourceCache, ClassLoader planClassLoader)
+            AgentPlan newPlan,
+            ResourceCache newResourceCache,
+            ClassLoader planClassLoader,
+            long planVersion)
             throws Exception {
         closeActiveRuntime();
-        activeRuntime = createPlanRuntime(newPlan, newResourceCache, planClassLoader);
+        activeRuntime = createPlanRuntime(newPlan, newResourceCache, planClassLoader, planVersion);
     }
 
-    /** Stops old-plan async work before its interpreter and Java-side resources are released. */
+    /** Stops old-plan async work while retaining its interpreter as the cleanup handle. */
     void quiescePlan() throws Exception {
         if (activeRuntime != null) {
             activeRuntime.quiesce();
         }
     }
 
+    @Nullable
+    private static String pythonArtifactPath(AgentPlan plan) {
+        return normalizedConfiguredPath(plan, PYTHON_ARTIFACT_PATH_CONFIG);
+    }
+
     private PythonResourceAdapterImpl initPythonResourceAdapter(
             AgentPlan agentPlan,
             ResourceCache resourceCache,
             JavaResourceAdapter javaResourceAdapter,
-            PythonInterpreter interpreter)
+            PythonInterpreter interpreter,
+            @Nullable String moduleNamespace)
             throws Exception {
         PythonResourceAdapterImpl pythonResourceAdapter =
                 new PythonResourceAdapterImpl(
-                        resourceCache.getResourceContext(), interpreter, javaResourceAdapter);
+                        resourceCache.getResourceContext(),
+                        interpreter,
+                        javaResourceAdapter,
+                        moduleNamespace);
         pythonResourceAdapter.open();
         PythonMCPResourceDiscovery.discoverPythonMCPResources(
                 agentPlan.getResourceProviders(), pythonResourceAdapter, resourceCache);
@@ -564,6 +682,7 @@ class PythonBridgeManager implements AutoCloseable {
         private final JavaResourceAdapter javaResourceAdapter;
         private final Mem0LongTermMemory longTermMemory;
         private final PythonInterpreter pythonInterpreter;
+        @Nullable private final String moduleNamespace;
         private boolean quiesced;
         private boolean closed;
 
@@ -573,13 +692,15 @@ class PythonBridgeManager implements AutoCloseable {
                 PythonResourceAdapterImpl pythonResourceAdapter,
                 JavaResourceAdapter javaResourceAdapter,
                 Mem0LongTermMemory longTermMemory,
-                PythonInterpreter pythonInterpreter) {
+                PythonInterpreter pythonInterpreter,
+                @Nullable String moduleNamespace) {
             this.pythonActionExecutor = pythonActionExecutor;
             this.pythonRunnerContext = pythonRunnerContext;
             this.pythonResourceAdapter = pythonResourceAdapter;
             this.javaResourceAdapter = javaResourceAdapter;
             this.longTermMemory = longTermMemory;
             this.pythonInterpreter = pythonInterpreter;
+            this.moduleNamespace = moduleNamespace;
             this.quiesced = false;
             this.closed = false;
         }
@@ -604,6 +725,17 @@ class PythonBridgeManager implements AutoCloseable {
                 quiesce();
             } catch (Exception e) {
                 firstException = e;
+            }
+            if (moduleNamespace != null) {
+                try {
+                    releasePythonModuleNamespace(pythonInterpreter, moduleNamespace);
+                } catch (Exception e) {
+                    if (firstException == null) {
+                        firstException = e;
+                    } else {
+                        firstException.addSuppressed(e);
+                    }
+                }
             }
             if (pythonInterpreter != null) {
                 try {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/PythonBridgeManager.java
@@ -34,6 +34,7 @@ import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.agents.runtime.python.utils.PythonResourceAdapterImpl;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.python.env.PythonDependencyInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ import static org.apache.flink.agents.plan.actions.Utils.supportAsync;
 
 /**
  * Owns the embedded Python runtime used by {@link ActionExecutionOperator} when an agent plan
- * contains Python actions or Python-defined resources.
+ * contains Python actions/resources or uses the Python pipeline wire format.
  *
  * <p>Owned state:
  *
@@ -62,11 +63,11 @@ import static org.apache.flink.agents.plan.actions.Utils.supportAsync;
  * </ul>
  *
  * <p>Lifecycle: instantiated by the operator's {@code open()} (lazy — not in the operator
- * constructor), then immediately initialized via {@link #open} in the same call. {@link #open} is a
- * no-op when the agent plan contains no Python actions and no Python resources — in that case all
- * accessors return {@code null} and {@link #isInitialized()} returns {@code false}. {@link
- * #close()} closes the owned resources in the reverse order of creation: {@code
- * pythonActionExecutor} → {@code pythonInterpreter} → {@code pythonEnvironmentManager}.
+ * constructor), then initialized via {@link #open}. At most one plan runtime is executable in the
+ * process: after the activation barrier drains the old plan, {@link #activatePlan} closes its
+ * interpreter and constructs the replacement. A Java-only plan still has a runtime when the
+ * surrounding pipeline uses Python wire encoding, because input/output conversion runs in Python.
+ * {@link #close()} closes the active interpreter and the shared environment manager.
  *
  * <p>Design constraint: package-private; no manager-to-manager held references. Other managers
  * receive what they need (e.g. the Python runner context, the action executor) via method
@@ -77,28 +78,39 @@ class PythonBridgeManager implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(PythonBridgeManager.class);
 
     private PythonEnvironmentManager pythonEnvironmentManager;
-    private PythonInterpreter pythonInterpreter;
-    private PythonActionExecutor pythonActionExecutor;
-    private PythonRunnerContextImpl pythonRunnerContext;
-    private PythonResourceAdapterImpl pythonResourceAdapter;
-    private JavaResourceAdapter javaResourceAdapter;
-    private Mem0LongTermMemory longTermMemory;
+    @Nullable private PlanPythonRuntime activeRuntime;
+    private final boolean pythonWireFormat;
+
+    private ExecutionConfig executionConfig;
+    private DistributedCache distributedCache;
+    private String[] tmpDirs;
+    private JobID jobId;
+    private FlinkAgentsMetricGroupImpl metricGroup;
+    private Runnable mailboxThreadChecker;
+    private String jobIdentifier;
+    private ClassLoader userCodeClassLoader;
+
     private boolean initialized;
 
     PythonBridgeManager() {
+        this(false);
+    }
+
+    PythonBridgeManager(boolean pythonWireFormat) {
+        this.pythonWireFormat = pythonWireFormat;
         this.initialized = false;
     }
 
     /**
      * Initializes the Python runtime if the agent plan needs it.
      *
-     * <p>Scans the agent plan for any {@link PythonFunction} action or {@link
-     * PythonResourceProvider}. If neither is present, this method is a no-op and {@link
-     * #isInitialized()} stays {@code false}. Otherwise it builds the {@link
-     * PythonEnvironmentManager}, opens an embedded {@link PythonInterpreter}, constructs the shared
-     * {@link PythonRunnerContextImpl}, wires the Java/Python resource adapters, and conditionally
-     * initializes the Python action executor and the Python resource adapter (each only when the
-     * corresponding component is present in the plan).
+     * <p>Scans the agent plan for any {@link PythonFunction} action, {@link
+     * PythonResourceProvider}, Mem0 configuration, or a Python pipeline wire format. If none is
+     * present, this method is a no-op and {@link #isInitialized()} stays {@code false}. Otherwise
+     * it builds the {@link PythonEnvironmentManager}, opens an embedded {@link PythonInterpreter},
+     * constructs the shared {@link PythonRunnerContextImpl}, wires the Java/Python resource
+     * adapters, and conditionally initializes the Python action executor and the Python resource
+     * adapter.
      *
      * @param agentPlan the agent plan describing actions and resources.
      * @param resourceCache the resource cache visible to both languages.
@@ -117,7 +129,7 @@ class PythonBridgeManager implements AutoCloseable {
             AgentPlan agentPlan,
             ResourceCache resourceCache,
             ExecutionConfig executionConfig,
-            org.apache.flink.api.common.cache.DistributedCache distributedCache,
+            DistributedCache distributedCache,
             String[] tmpDirs,
             JobID jobId,
             FlinkAgentsMetricGroupImpl metricGroup,
@@ -125,58 +137,128 @@ class PythonBridgeManager implements AutoCloseable {
             String jobIdentifier,
             ClassLoader userCodeClassLoader)
             throws Exception {
-        boolean containPythonAction =
-                agentPlan.getActions().values().stream()
-                        .anyMatch(action -> action.getExec() instanceof PythonFunction);
+        this.executionConfig = executionConfig;
+        this.distributedCache = distributedCache;
+        this.tmpDirs = tmpDirs;
+        this.jobId = jobId;
+        this.metricGroup = metricGroup;
+        this.mailboxThreadChecker = mailboxThreadChecker;
+        this.jobIdentifier = jobIdentifier;
+        this.userCodeClassLoader = userCodeClassLoader;
 
-        boolean containPythonResource =
-                agentPlan.getResourceProviders().values().stream()
-                        .anyMatch(
-                                resourceProviderMap ->
-                                        resourceProviderMap.values().stream()
-                                                .anyMatch(
-                                                        resourceProvider ->
-                                                                resourceProvider
-                                                                        instanceof
-                                                                        PythonResourceProvider));
+        activeRuntime = createPlanRuntime(agentPlan, resourceCache);
+    }
 
+    @Nullable
+    private PlanPythonRuntime createPlanRuntime(AgentPlan agentPlan, ResourceCache resourceCache)
+            throws Exception {
+        boolean containPythonAction = containsPythonAction(agentPlan);
+        boolean containPythonResource = containsPythonResource(agentPlan);
         boolean mem0Configured = isMem0Configured(agentPlan);
 
-        if (containPythonAction || containPythonResource || mem0Configured) {
-            LOG.debug("Begin initialize PythonEnvironmentManager.");
-            PythonDependencyInfo dependencyInfo =
-                    PythonDependencyInfo.create(
-                            executionConfig.toConfiguration(), distributedCache);
-            pythonEnvironmentManager =
-                    new PythonEnvironmentManager(
-                            dependencyInfo, tmpDirs, new HashMap<>(System.getenv()), jobId);
-            pythonEnvironmentManager.open();
-            EmbeddedPythonEnvironment env = pythonEnvironmentManager.createEnvironment();
-            pythonInterpreter = env.getInterpreter();
-            pythonRunnerContext =
+        if (!needsPythonRuntime(agentPlan)) {
+            return null;
+        }
+
+        PythonInterpreter interpreter = createPythonInterpreter();
+        PythonActionExecutor pythonActionExecutor = null;
+        try {
+            PythonRunnerContextImpl pythonRunnerContext =
                     new PythonRunnerContextImpl(
                             metricGroup,
                             mailboxThreadChecker,
                             agentPlan,
                             resourceCache,
                             jobIdentifier);
-
-            javaResourceAdapter =
+            JavaResourceAdapter javaResourceAdapter =
                     new JavaResourceAdapter(
-                            resourceCache.getResourceContext(),
-                            pythonInterpreter,
-                            userCodeClassLoader);
+                            resourceCache.getResourceContext(), interpreter, userCodeClassLoader);
+
+            PythonResourceAdapterImpl pythonResourceAdapter = null;
             if (containPythonResource || mem0Configured) {
-                initPythonResourceAdapter(agentPlan, resourceCache);
+                pythonResourceAdapter =
+                        initPythonResourceAdapter(
+                                agentPlan, resourceCache, javaResourceAdapter, interpreter);
             }
-            if (containPythonAction || mem0Configured) {
-                initPythonActionExecutor(agentPlan, jobIdentifier);
+
+            if (containPythonAction || mem0Configured || pythonWireFormat) {
+                pythonActionExecutor =
+                        initPythonActionExecutor(
+                                agentPlan, javaResourceAdapter, pythonRunnerContext, interpreter);
             }
+
+            Mem0LongTermMemory longTermMemory = null;
             if (mem0Configured) {
-                wireLongTermMemory();
+                longTermMemory =
+                        wireLongTermMemory(
+                                pythonActionExecutor, pythonResourceAdapter, interpreter);
             }
-            initialized = true;
+
+            return new PlanPythonRuntime(
+                    pythonActionExecutor,
+                    pythonRunnerContext,
+                    pythonResourceAdapter,
+                    javaResourceAdapter,
+                    longTermMemory,
+                    interpreter);
+        } catch (Exception creationFailure) {
+            if (pythonActionExecutor != null) {
+                try {
+                    pythonActionExecutor.close();
+                } catch (Exception closeFailure) {
+                    creationFailure.addSuppressed(closeFailure);
+                }
+            }
+            try {
+                interpreter.close();
+            } catch (Exception closeFailure) {
+                creationFailure.addSuppressed(closeFailure);
+            }
+            throw creationFailure;
         }
+    }
+
+    private PythonInterpreter createPythonInterpreter() throws Exception {
+        ensurePythonEnvironment();
+        EmbeddedPythonEnvironment env = pythonEnvironmentManager.createEnvironment();
+        return env.getInterpreter();
+    }
+
+    private void ensurePythonEnvironment() throws Exception {
+        if (initialized) {
+            return;
+        }
+        LOG.debug("Begin initialize PythonEnvironmentManager.");
+        PythonDependencyInfo dependencyInfo =
+                PythonDependencyInfo.create(executionConfig.toConfiguration(), distributedCache);
+        pythonEnvironmentManager =
+                new PythonEnvironmentManager(
+                        dependencyInfo, tmpDirs, new HashMap<>(System.getenv()), jobId);
+        pythonEnvironmentManager.open();
+        initialized = true;
+    }
+
+    private boolean containsPythonAction(AgentPlan agentPlan) {
+        return agentPlan.getActions().values().stream()
+                .anyMatch(action -> action.getExec() instanceof PythonFunction);
+    }
+
+    private boolean containsPythonResource(AgentPlan agentPlan) {
+        return agentPlan.getResourceProviders().values().stream()
+                .anyMatch(
+                        resourceProviderMap ->
+                                resourceProviderMap.values().stream()
+                                        .anyMatch(
+                                                resourceProvider ->
+                                                        resourceProvider
+                                                                instanceof PythonResourceProvider));
+    }
+
+    private boolean needsPythonRuntime(AgentPlan agentPlan) {
+        return pythonWireFormat
+                || containsPythonAction(agentPlan)
+                || containsPythonResource(agentPlan)
+                || isMem0Configured(agentPlan);
     }
 
     /**
@@ -220,9 +302,12 @@ class PythonBridgeManager implements AutoCloseable {
      * {@code create_flink_runner_context} already initialised via {@code _init_long_term_memory})
      * and wrap it as a Java {@link Mem0LongTermMemory}.
      */
-    private void wireLongTermMemory() {
+    private Mem0LongTermMemory wireLongTermMemory(
+            PythonActionExecutor pythonActionExecutor,
+            PythonResourceAdapterImpl pythonResourceAdapter,
+            PythonInterpreter interpreter) {
         PyObject pyCtx = pythonActionExecutor.getPythonRunnerContext();
-        Object pyLtm = pythonInterpreter.invoke("python_java_utils.get_long_term_memory", pyCtx);
+        Object pyLtm = interpreter.invokeMethod("python_java_utils", "get_long_term_memory", pyCtx);
         if (pyLtm == null) {
             throw new IllegalStateException(
                     String.format(
@@ -234,47 +319,85 @@ class PythonBridgeManager implements AutoCloseable {
                             LongTermMemoryOptions.Mem0.EMBEDDING_MODEL_SETUP.getKey(),
                             LongTermMemoryOptions.Mem0.VECTOR_STORE.getKey()));
         }
-        longTermMemory = new Mem0LongTermMemory(pythonResourceAdapter, (PyObject) pyLtm);
+        return new Mem0LongTermMemory(pythonResourceAdapter, (PyObject) pyLtm);
     }
 
-    private void initPythonActionExecutor(AgentPlan agentPlan, String jobIdentifier)
+    private PythonActionExecutor initPythonActionExecutor(
+            AgentPlan agentPlan,
+            JavaResourceAdapter javaResourceAdapter,
+            PythonRunnerContextImpl pythonRunnerContext,
+            PythonInterpreter interpreter)
             throws Exception {
-        pythonActionExecutor =
+        PythonActionExecutor pythonActionExecutor =
                 new PythonActionExecutor(
-                        pythonInterpreter,
+                        interpreter,
                         agentPlan,
                         javaResourceAdapter,
                         pythonRunnerContext,
                         jobIdentifier);
-        pythonActionExecutor.open();
+        try {
+            pythonActionExecutor.open();
+            return pythonActionExecutor;
+        } catch (Exception openFailure) {
+            try {
+                pythonActionExecutor.close();
+            } catch (Exception closeFailure) {
+                openFailure.addSuppressed(closeFailure);
+            }
+            throw openFailure;
+        }
     }
 
-    private void initPythonResourceAdapter(AgentPlan agentPlan, ResourceCache resourceCache)
+    /**
+     * Rebuilds the Python-visible runtime while the checkpoint barrier still blocks input. The old
+     * runtime is quiesced and closed before the replacement is constructed and its declared Python
+     * action entries are resolved.
+     *
+     * <p>Any failure escapes the barrier. There is no local rollback after the old runtime has been
+     * closed; the task must recover from the previous completed checkpoint.
+     */
+    void activatePlan(AgentPlan newPlan, ResourceCache newResourceCache) throws Exception {
+        closeActiveRuntime();
+        activeRuntime = createPlanRuntime(newPlan, newResourceCache);
+    }
+
+    /** Stops old-plan async work before its interpreter and Java-side resources are released. */
+    void quiescePlan() throws Exception {
+        if (activeRuntime != null) {
+            activeRuntime.quiesce();
+        }
+    }
+
+    private PythonResourceAdapterImpl initPythonResourceAdapter(
+            AgentPlan agentPlan,
+            ResourceCache resourceCache,
+            JavaResourceAdapter javaResourceAdapter,
+            PythonInterpreter interpreter)
             throws Exception {
-        pythonResourceAdapter =
+        PythonResourceAdapterImpl pythonResourceAdapter =
                 new PythonResourceAdapterImpl(
-                        resourceCache.getResourceContext(), pythonInterpreter, javaResourceAdapter);
+                        resourceCache.getResourceContext(), interpreter, javaResourceAdapter);
         pythonResourceAdapter.open();
         PythonMCPResourceDiscovery.discoverPythonMCPResources(
                 agentPlan.getResourceProviders(), pythonResourceAdapter, resourceCache);
+        return pythonResourceAdapter;
     }
 
     /**
-     * @return the Python action executor, or {@code null} if the agent plan contains no Python
-     *     actions (or {@link #open} has not yet been called).
+     * @return the Python action executor of the active plan, or {@code null}.
      */
     @Nullable
     PythonActionExecutor getPythonActionExecutor() {
-        return pythonActionExecutor;
+        return activeRuntime == null ? null : activeRuntime.pythonActionExecutor;
     }
 
     /**
-     * @return the Python runner context, or {@code null} if no Python runtime was initialized
-     *     because the agent plan has neither Python actions nor Python resources.
+     * @return the Python runner context for the initial plan, or {@code null} if no Python runtime
+     *     was initialized because the agent plan has neither Python actions nor Python resources.
      */
     @Nullable
     PythonRunnerContextImpl getPythonRunnerContext() {
-        return pythonRunnerContext;
+        return activeRuntime == null ? null : activeRuntime.pythonRunnerContext;
     }
 
     /**
@@ -282,23 +405,108 @@ class PythonBridgeManager implements AutoCloseable {
      */
     @Nullable
     Mem0LongTermMemory getLongTermMemory() {
-        return longTermMemory;
+        return activeRuntime == null ? null : activeRuntime.longTermMemory;
     }
 
     boolean isInitialized() {
         return initialized;
     }
 
+    private void closeActiveRuntime() throws Exception {
+        PlanPythonRuntime runtime = activeRuntime;
+        activeRuntime = null;
+        if (runtime != null) {
+            runtime.close();
+        }
+    }
+
     @Override
     public void close() throws Exception {
-        if (pythonActionExecutor != null) {
-            pythonActionExecutor.close();
-        }
-        if (pythonInterpreter != null) {
-            pythonInterpreter.close();
+        Exception firstException = null;
+        try {
+            closeActiveRuntime();
+        } catch (Exception e) {
+            firstException = e;
         }
         if (pythonEnvironmentManager != null) {
-            pythonEnvironmentManager.close();
+            try {
+                pythonEnvironmentManager.close();
+            } catch (Exception e) {
+                if (firstException == null) {
+                    firstException = e;
+                } else {
+                    firstException.addSuppressed(e);
+                }
+            }
+        }
+        if (firstException != null) {
+            throw firstException;
+        }
+    }
+
+    static final class PlanPythonRuntime implements AutoCloseable {
+        private final PythonActionExecutor pythonActionExecutor;
+        private final PythonRunnerContextImpl pythonRunnerContext;
+        private final PythonResourceAdapterImpl pythonResourceAdapter;
+        private final JavaResourceAdapter javaResourceAdapter;
+        private final Mem0LongTermMemory longTermMemory;
+        private final PythonInterpreter pythonInterpreter;
+        private boolean quiesced;
+        private boolean closed;
+
+        PlanPythonRuntime(
+                PythonActionExecutor pythonActionExecutor,
+                PythonRunnerContextImpl pythonRunnerContext,
+                PythonResourceAdapterImpl pythonResourceAdapter,
+                JavaResourceAdapter javaResourceAdapter,
+                Mem0LongTermMemory longTermMemory,
+                PythonInterpreter pythonInterpreter) {
+            this.pythonActionExecutor = pythonActionExecutor;
+            this.pythonRunnerContext = pythonRunnerContext;
+            this.pythonResourceAdapter = pythonResourceAdapter;
+            this.javaResourceAdapter = javaResourceAdapter;
+            this.longTermMemory = longTermMemory;
+            this.pythonInterpreter = pythonInterpreter;
+            this.quiesced = false;
+            this.closed = false;
+        }
+
+        private void quiesce() throws Exception {
+            if (quiesced || closed) {
+                return;
+            }
+            if (pythonActionExecutor != null) {
+                pythonActionExecutor.close();
+            }
+            quiesced = true;
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (closed) {
+                return;
+            }
+            Exception firstException = null;
+            try {
+                quiesce();
+            } catch (Exception e) {
+                firstException = e;
+            }
+            if (pythonInterpreter != null) {
+                try {
+                    pythonInterpreter.close();
+                } catch (Exception e) {
+                    if (firstException == null) {
+                        firstException = e;
+                    } else {
+                        firstException.addSuppressed(e);
+                    }
+                }
+            }
+            closed = true;
+            if (firstException != null) {
+                throw firstException;
+            }
         }
     }
 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanIds.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanIds.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator.coordinator;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Content identity of an AgentPlan: {@code planId = sha256(canonicalPlanJson)}.
+ *
+ * <p>The coordinator canonicalizes the submitted JSON once and mints the planId; subtasks verify
+ * the signature over the received bytes. The planId only answers "is this the same plan" — recency
+ * is expressed separately by the latest pointer ({@code planVersion + latestPlanId}).
+ */
+public final class PlanIds {
+
+    private static final JsonMapper CANONICAL_MAPPER =
+            JsonMapper.builder()
+                    .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                    .build();
+
+    private PlanIds() {}
+
+    /**
+     * Rewrites JSON into canonical form: recursively sorted object keys, no insignificant
+     * whitespace. Two semantically identical plans always canonicalize to the same string.
+     */
+    public static String canonicalize(String json) throws IOException {
+        Object tree = CANONICAL_MAPPER.readValue(json, Object.class);
+        return CANONICAL_MAPPER.writeValueAsString(tree);
+    }
+
+    /** sha256 hex over the exact JSON string bytes (UTF-8). */
+    public static String planIdOf(String json) {
+        return sha256Hex(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable.", e);
+        }
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanIds.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanIds.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -53,6 +55,11 @@ public final class PlanIds {
     /** sha256 hex over the exact JSON string bytes (UTF-8). */
     public static String planIdOf(String json) {
         return sha256Hex(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** sha256 hex of a local file's contents; used to verify plan artifacts before loading. */
+    public static String sha256HexOfFile(Path path) throws IOException {
+        return sha256Hex(Files.readAllBytes(path));
     }
 
     public static String sha256Hex(byte[] bytes) {

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateCoordinator.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateCoordinator.java
@@ -1,0 +1,538 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator.coordinator;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateEvent;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateRequest;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateResponse;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.util.FlinkException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * JM-side coordinator implementing the <b>two-phase plan switch</b>: the single point that decides
+ * both <i>which</i> plan is next and <i>at which checkpoint</i> every subtask switches to it.
+ *
+ * <p><b>Phase 1 — establish the lower bound.</b> An accepted update only becomes an in-memory
+ * {@code candidate}: nothing is sent to the subtasks yet. The next completed checkpoint K still
+ * snapshots only the active plan. The candidate is announced after K completes, so every subtask
+ * receives the instruction after its own K snapshot.
+ *
+ * <p><b>Phase 2 — switch.</b> Subtasks apply the standing rule "prepare on receipt, switch at the
+ * next barrier". The coordinator guarantees they all resolve this to the <i>same</i> barrier: its
+ * snapshot for the following checkpoint completes only after every announce delivery is confirmed,
+ * and Flink injects that checkpoint's barriers at the sources only after all coordinator snapshots
+ * complete — so "instruction received" causally precedes "any such barrier exists". That snapshot
+ * records the candidate as active: restoring it implies the switch happened at its barrier.
+ *
+ * <p>Only the active plan is checkpointed. The candidate and all delivery bookkeeping are volatile:
+ * a global recovery before the activation checkpoint completes deliberately abandons the update. A
+ * subtask failure while a candidate is in flight is escalated through {@link Context#failJob} so
+ * every task and this coordinator recover from the same completed checkpoint. While a candidate
+ * awaits activation (and while any checkpoint is in flight) new updates are rejected.
+ *
+ * <p>Assumes no concurrent checkpoints ({@code maxConcurrentCheckpoints = 1}, Flink's default).
+ */
+public class PlanUpdateCoordinator implements OperatorCoordinator, CoordinationRequestHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PlanUpdateCoordinator.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final long NO_ACTIVATION_CHECKPOINT = -1L;
+
+    private final Context context;
+    private final Map<Integer, SubtaskGateway> gateways = new ConcurrentHashMap<>();
+
+    // Durable state: the plan in the latest completed activation checkpoint. Null means the
+    // bootstrap plan from the JobGraph.
+    @Nullable private volatile PlanRecord active;
+
+    // Volatile transaction state. K completes before candidatePassedCheckpoint becomes true and
+    // the event is announced. The candidate remains present through K+1 so a barrier-time failure
+    // can still be recognized and escalated to global recovery.
+    @Nullable private volatile PlanRecord candidate;
+    private volatile boolean candidatePassedCheckpoint;
+    private volatile long activationCheckpointId = NO_ACTIVATION_CHECKPOINT;
+    private volatile boolean candidateFailureEscalated;
+
+    // Delivery confirmations of announced events. The next checkpoint's snapshot completes only
+    // after these are done, which fences "instruction received" before "next barrier injected".
+    private final List<CompletableFuture<?>> pendingDeliveries = new CopyOnWriteArrayList<>();
+
+    private final Set<Long> checkpointsInFlight = ConcurrentHashMap.newKeySet();
+
+    // Records which candidate was present when checkpoint K took its coordinator snapshot. This
+    // makes the lower-bound qualification explicit instead of letting a later request borrow an
+    // already-completed checkpoint. Accessed only while holding this coordinator's monitor.
+    private final Map<Long, PlanRecord> lowerBoundCandidates = new HashMap<>();
+
+    PlanUpdateCoordinator(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public CompletableFuture<CoordinationResponse> handleCoordinationRequest(
+            CoordinationRequest request) {
+        IllegalStateException rejection = currentRequestRejection();
+        if (rejection != null) {
+            return CompletableFuture.failedFuture(rejection);
+        }
+        String rawJson = ((PlanUpdateRequest) request).agentPlanJson;
+        String canonicalJson;
+        String planId;
+        try {
+            canonicalJson = PlanIds.canonicalize(rawJson);
+            // Static validation: content errors are rejected before accepting a candidate.
+            OBJECT_MAPPER.readValue(canonicalJson, AgentPlan.class);
+            planId = PlanIds.planIdOf(canonicalJson);
+        } catch (Exception e) {
+            LOG.warn("Rejecting AgentPlan update at the coordinator.", e);
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException(
+                            "Rejected AgentPlan update: " + e.getMessage(), e));
+        }
+
+        PlanRecord next;
+        synchronized (this) {
+            // Validation deliberately happens outside the lock. Re-check under the same lock used
+            // by checkpointCoordinator so a request cannot slip behind a checkpoint snapshot and
+            // then incorrectly treat that checkpoint as K.
+            rejection = currentRequestRejection();
+            if (rejection != null) {
+                return CompletableFuture.failedFuture(rejection);
+            }
+            long nextVersion = active == null ? 1L : active.planVersion + 1;
+            next = new PlanRecord(nextVersion, planId, canonicalJson);
+            candidate = next;
+            candidatePassedCheckpoint = false;
+            activationCheckpointId = NO_ACTIVATION_CHECKPOINT;
+            candidateFailureEscalated = false;
+        }
+        LOG.info(
+                "Accepted AgentPlan candidate with planVersion {}; it will be announced after all "
+                        + "subtasks complete the next checkpoint and switched at the checkpoint "
+                        + "after that.",
+                next.planVersion);
+        return CompletableFuture.completedFuture(
+                new PlanUpdateResponse(next.planVersion, next.planId, gateways.size()));
+    }
+
+    /**
+     * Coordinator snapshot: (a) fences K+1 behind all announce deliveries, (b) records the
+     * candidate as active in K+1 — a restore of that checkpoint implies every subtask switched at
+     * its barrier — and (c) persists only the active plan. K still records the old active plan.
+     */
+    @Override
+    public void checkpointCoordinator(long checkpointId, CompletableFuture<byte[]> result) {
+        final List<CompletableFuture<?>> outstanding;
+        final boolean activationSnapshot;
+        final PlanRecord checkpointCandidate;
+        synchronized (this) {
+            checkpointsInFlight.add(checkpointId);
+            outstanding = new ArrayList<>(pendingDeliveries);
+            checkpointCandidate = candidate;
+            activationSnapshot = checkpointCandidate != null && candidatePassedCheckpoint;
+            if (checkpointCandidate != null && !activationSnapshot && !candidateFailureEscalated) {
+                lowerBoundCandidates.put(checkpointId, checkpointCandidate);
+            }
+        }
+        CompletableFuture.allOf(outstanding.toArray(new CompletableFuture<?>[0]))
+                .whenComplete(
+                        (ignored, deliveryFailure) -> {
+                            if (deliveryFailure != null) {
+                                if (activationSnapshot) {
+                                    failCurrentUpdateGlobally(
+                                            "Failed to deliver the AgentPlan candidate to every "
+                                                    + "subtask.",
+                                            deliveryFailure,
+                                            checkpointCandidate,
+                                            checkpointId);
+                                }
+                                result.completeExceptionally(deliveryFailure);
+                                return;
+                            }
+                            try {
+                                synchronized (this) {
+                                    if (!checkpointsInFlight.contains(checkpointId)) {
+                                        result.completeExceptionally(
+                                                new IllegalStateException(
+                                                        "Checkpoint "
+                                                                + checkpointId
+                                                                + " was aborted before the "
+                                                                + "coordinator snapshot completed."));
+                                        return;
+                                    }
+
+                                    PlanRecord snapshotActive = active;
+                                    if (activationSnapshot) {
+                                        if (candidate != checkpointCandidate
+                                                || !candidatePassedCheckpoint) {
+                                            throw new IllegalStateException(
+                                                    "AgentPlan candidate changed while "
+                                                            + "checkpoint "
+                                                            + checkpointId
+                                                            + " was waiting for delivery.");
+                                        }
+                                        LOG.info(
+                                                "Activating AgentPlan planVersion {} at checkpoint"
+                                                        + " {}: all subtasks switch at its barrier.",
+                                                candidate.planVersion,
+                                                checkpointId);
+                                        activationCheckpointId = checkpointId;
+                                        snapshotActive = checkpointCandidate;
+                                        pendingDeliveries.removeAll(outstanding);
+                                    }
+                                    result.complete(
+                                            OBJECT_MAPPER.writeValueAsBytes(
+                                                    new CoordinatorState(snapshotActive)));
+                                }
+                            } catch (Exception e) {
+                                if (activationSnapshot) {
+                                    failCurrentUpdateGlobally(
+                                            "Failed to snapshot the activating AgentPlan "
+                                                    + "candidate.",
+                                            e,
+                                            checkpointCandidate,
+                                            checkpointId);
+                                }
+                                result.completeExceptionally(e);
+                            }
+                        });
+    }
+
+    /** Completes K's lower-bound fence or commits the activation checkpoint K+1. */
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        PlanRecord candidateToAnnounce;
+        int parallelism = 0;
+        String failureMessage = null;
+        RuntimeException failureCause = null;
+        synchronized (this) {
+            if (!checkpointsInFlight.remove(checkpointId)) {
+                return;
+            }
+            PlanRecord lowerBoundCandidate = lowerBoundCandidates.remove(checkpointId);
+            if (activationCheckpointId == checkpointId) {
+                if (candidate == null) {
+                    throw new IllegalStateException(
+                            "Activation checkpoint completed without an AgentPlan candidate.");
+                }
+                active = candidate;
+                candidate = null;
+                candidatePassedCheckpoint = false;
+                activationCheckpointId = NO_ACTIVATION_CHECKPOINT;
+                candidateFailureEscalated = false;
+                return;
+            }
+
+            // Qualify the candidate while holding the same monitor used by request admission and
+            // checkpointCoordinator. Otherwise a request accepted immediately after a checkpoint
+            // completed could accidentally borrow that already-finished checkpoint as K.
+            if (lowerBoundCandidate == null
+                    || candidate != lowerBoundCandidate
+                    || candidatePassedCheckpoint
+                    || candidateFailureEscalated) {
+                return;
+            }
+            candidatePassedCheckpoint = true;
+            candidateToAnnounce = candidate;
+            try {
+                parallelism = context.currentParallelism();
+                if (gateways.size() != parallelism) {
+                    failureMessage =
+                            "Cannot announce AgentPlan candidate planVersion "
+                                    + candidate.planVersion
+                                    + ": expected "
+                                    + parallelism
+                                    + " ready subtasks but found "
+                                    + gateways.size()
+                                    + '.';
+                } else {
+                    PlanUpdateEvent event = toEvent(candidateToAnnounce);
+                    for (int i = 0; i < parallelism; i++) {
+                        SubtaskGateway gateway = gateways.get(i);
+                        pendingDeliveries.add(gateway.sendEvent(event));
+                    }
+                }
+            } catch (RuntimeException e) {
+                failureMessage = "Failed to announce the AgentPlan candidate to every subtask.";
+                failureCause = e;
+            }
+        }
+        if (failureMessage != null) {
+            failCurrentUpdateGlobally(
+                    failureMessage, failureCause, candidateToAnnounce, NO_ACTIVATION_CHECKPOINT);
+            return;
+        }
+        LOG.info(
+                "Announced AgentPlan candidate planVersion {} to {} subtasks; they switch at the "
+                        + "next checkpoint barrier.",
+                candidateToAnnounce.planVersion,
+                parallelism);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        PlanRecord candidateAtAbort = null;
+        synchronized (this) {
+            checkpointsInFlight.remove(checkpointId);
+            lowerBoundCandidates.remove(checkpointId);
+            if (activationCheckpointId == checkpointId) {
+                candidateAtAbort = candidate;
+            }
+        }
+        if (candidateAtAbort != null) {
+            failCurrentUpdateGlobally(
+                    "AgentPlan activation checkpoint "
+                            + checkpointId
+                            + " was aborted after its barrier could have switched subtasks.",
+                    null,
+                    candidateAtAbort,
+                    NO_ACTIVATION_CHECKPOINT);
+        }
+    }
+
+    /**
+     * Registers the current attempt. The active plan is never sent: every subtask restores it from
+     * union state. A candidate is not replayed after recovery; a global reset discards it. Once a
+     * candidate was announced, another ready attempt means the attempt set changed during the
+     * update and therefore requires global recovery.
+     */
+    @Override
+    public void executionAttemptReady(int subtask, int attempt, SubtaskGateway gateway) {
+        PlanRecord announcedCandidate = null;
+        synchronized (this) {
+            gateways.put(subtask, gateway);
+            if (candidate != null && candidatePassedCheckpoint && !candidateFailureEscalated) {
+                announcedCandidate = candidate;
+            }
+        }
+        if (announcedCandidate != null) {
+            failCurrentUpdateGlobally(
+                    "Subtask "
+                            + subtask
+                            + " attempt "
+                            + attempt
+                            + " became ready after the AgentPlan candidate was announced.",
+                    null,
+                    announcedCandidate,
+                    NO_ACTIVATION_CHECKPOINT);
+        }
+    }
+
+    @Override
+    public void executionAttemptFailed(int subtask, int attempt, Throwable reason) {
+        PlanRecord failedCandidate;
+        synchronized (this) {
+            gateways.remove(subtask);
+            failedCandidate = candidate;
+        }
+        if (failedCandidate != null) {
+            failCurrentUpdateGlobally(
+                    "Subtask "
+                            + subtask
+                            + " attempt "
+                            + attempt
+                            + " failed while applying the AgentPlan candidate.",
+                    reason,
+                    failedCandidate,
+                    NO_ACTIVATION_CHECKPOINT);
+        }
+    }
+
+    @Override
+    public void resetToCheckpoint(long checkpointId, byte[] data) {
+        synchronized (this) {
+            checkpointsInFlight.clear();
+            pendingDeliveries.clear();
+            gateways.clear();
+            lowerBoundCandidates.clear();
+            try {
+                CoordinatorState state =
+                        (data == null || data.length == 0)
+                                ? new CoordinatorState(null)
+                                : OBJECT_MAPPER.readValue(data, CoordinatorState.class);
+                active = state.active;
+                candidate = null;
+                candidatePassedCheckpoint = false;
+                activationCheckpointId = NO_ACTIVATION_CHECKPOINT;
+                candidateFailureEscalated = false;
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to restore coordinator plan state.", e);
+            }
+        }
+    }
+
+    private synchronized @Nullable IllegalStateException currentRequestRejection() {
+        if (!checkpointsInFlight.isEmpty()) {
+            return new IllegalStateException(
+                    "A checkpoint is in progress; the AgentPlan update is rejected to keep the "
+                            + "switch decision unambiguous. Retry shortly.");
+        }
+        if (candidate != null) {
+            return new IllegalStateException(
+                    "A previous AgentPlan update is a candidate and not yet effective; one update "
+                            + "is processed at a time. Retry after it activates.");
+        }
+        return null;
+    }
+
+    private void failCurrentUpdateGlobally(
+            String message,
+            @Nullable Throwable cause,
+            @Nullable PlanRecord expectedCandidate,
+            long expectedCheckpointId) {
+        final long planVersion;
+        synchronized (this) {
+            if (candidate == null
+                    || candidateFailureEscalated
+                    || (expectedCandidate != null && candidate != expectedCandidate)
+                    || (expectedCheckpointId != NO_ACTIVATION_CHECKPOINT
+                            && !checkpointsInFlight.contains(expectedCheckpointId))) {
+                return;
+            }
+            candidateFailureEscalated = true;
+            planVersion = candidate.planVersion;
+        }
+
+        String failureMessage =
+                message + " Failing the job for AgentPlan planVersion " + planVersion + '.';
+        FlinkException failure =
+                cause == null
+                        ? new FlinkException(failureMessage)
+                        : new FlinkException(failureMessage, cause);
+        LOG.warn(failureMessage, cause);
+        context.failJob(failure);
+    }
+
+    private static PlanUpdateEvent toEvent(PlanRecord plan) {
+        return new PlanUpdateEvent(plan.planVersion, plan.planId, plan.canonicalPlanJson);
+    }
+
+    @Override
+    public void start() {}
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void handleEventFromOperator(int subtask, int attempt, OperatorEvent event) {}
+
+    @Override
+    public void subtaskReset(int subtask, long checkpointId) {
+        PlanRecord resetCandidate;
+        synchronized (this) {
+            resetCandidate = candidate;
+        }
+        if (resetCandidate != null) {
+            failCurrentUpdateGlobally(
+                    "Subtask "
+                            + subtask
+                            + " was reset to checkpoint "
+                            + checkpointId
+                            + " while an AgentPlan update was in progress.",
+                    null,
+                    resetCandidate,
+                    NO_ACTIVATION_CHECKPOINT);
+        }
+    }
+
+    @VisibleForTesting
+    @Nullable
+    PlanRecord getActiveForTesting() {
+        return active;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    PlanRecord getCandidateForTesting() {
+        return candidate;
+    }
+
+    /** One immutable plan record: {@code planVersion + content identity + full content}. */
+    public static final class PlanRecord implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public long planVersion;
+        public String planId;
+        public String canonicalPlanJson;
+
+        public PlanRecord() {}
+
+        public PlanRecord(long planVersion, String planId, String canonicalPlanJson) {
+            this.planVersion = planVersion;
+            this.planId = planId;
+            this.canonicalPlanJson = canonicalPlanJson;
+        }
+    }
+
+    /** Checkpointed coordinator state: only the plan committed by a completed checkpoint. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class CoordinatorState implements Serializable {
+        private static final long serialVersionUID = 1L;
+        @Nullable public PlanRecord active;
+
+        public CoordinatorState() {}
+
+        public CoordinatorState(@Nullable PlanRecord active) {
+            this.active = active;
+        }
+    }
+
+    /** Factory wired into {@code CoordinatedOperatorFactory.getCoordinatorProvider}. */
+    public static class Provider implements OperatorCoordinator.Provider {
+        private static final long serialVersionUID = 1L;
+        private final OperatorID operatorId;
+
+        public Provider(OperatorID operatorId) {
+            this.operatorId = operatorId;
+        }
+
+        @Override
+        public OperatorID getOperatorId() {
+            return operatorId;
+        }
+
+        @Override
+        public OperatorCoordinator create(Context context) {
+            return new PlanUpdateCoordinator(context);
+        }
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateMessages.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateMessages.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator.coordinator;
+
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+
+/** Wire types for pushing AgentPlan updates through an {@code OperatorCoordinator}. */
+public final class PlanUpdateMessages {
+
+    private PlanUpdateMessages() {}
+
+    /**
+     * Coordinator → subtask: the plan to switch to. Carries the coordinator-minted planVersion, the
+     * content signature, and the canonical plan JSON so subtasks can verify integrity and ignore
+     * duplicate deliveries idempotently.
+     */
+    public static final class PlanUpdateEvent implements OperatorEvent {
+        private static final long serialVersionUID = 2L;
+        public final long planVersion;
+        public final String planId;
+        public final String canonicalPlanJson;
+
+        public PlanUpdateEvent(long planVersion, String planId, String canonicalPlanJson) {
+            this.planVersion = planVersion;
+            this.planId = planId;
+            this.canonicalPlanJson = canonicalPlanJson;
+        }
+    }
+
+    /** REST/CLI → coordinator: publish a new plan. */
+    public static final class PlanUpdateRequest implements CoordinationRequest {
+        private static final long serialVersionUID = 1L;
+        public final String agentPlanJson;
+
+        public PlanUpdateRequest(String agentPlanJson) {
+            this.agentPlanJson = agentPlanJson;
+        }
+    }
+
+    /**
+     * Coordinator → caller: the minted planVersion and planId for candidate acceptance. The frozen
+     * {@code subtasksNotified} field records how many subtask gateways were registered when the
+     * request was accepted; the volatile candidate is not announced until checkpoint K completes.
+     */
+    public static final class PlanUpdateResponse implements CoordinationResponse {
+        private static final long serialVersionUID = 2L;
+        public final long planVersion;
+        public final String planId;
+        public final int subtasksNotified;
+
+        public PlanUpdateResponse(long planVersion, String planId, int subtasksNotified) {
+            this.planVersion = planVersion;
+            this.planId = planId;
+            this.subtasksNotified = subtasksNotified;
+        }
+    }
+}

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -35,38 +35,51 @@ import static org.apache.flink.util.Preconditions.checkState;
 /** Execute the corresponding Python action in the agent. */
 public class PythonActionExecutor {
 
+    private static final String FUNCTION_MODULE = "__fa_function_module";
+    private static final String RUNNER_CONTEXT_MODULE = "__fa_runner_context_module";
+    private static final String JAVA_UTILS_MODULE = "__fa_java_utils_module";
     private static final String PYTHON_IMPORTS =
-            "from flink_agents.plan import function\n"
-                    + "from flink_agents.runtime import flink_runner_context\n"
-                    + "from flink_agents.runtime import python_java_utils";
+            "from flink_agents.plan import function as "
+                    + FUNCTION_MODULE
+                    + "\n"
+                    + "from flink_agents.runtime import flink_runner_context as "
+                    + RUNNER_CONTEXT_MODULE
+                    + "\n"
+                    + "from flink_agents.runtime import python_java_utils as "
+                    + JAVA_UTILS_MODULE
+                    + "\n"
+                    + "function = "
+                    + FUNCTION_MODULE
+                    + "\n"
+                    + "flink_runner_context = "
+                    + RUNNER_CONTEXT_MODULE
+                    + "\n"
+                    + "python_java_utils = "
+                    + JAVA_UTILS_MODULE
+                    + "\n";
 
     // =========== RUNNER CONTEXT ===========
-    private static final String CREATE_FLINK_RUNNER_CONTEXT =
-            "flink_runner_context.create_flink_runner_context";
+    private static final String CREATE_FLINK_RUNNER_CONTEXT = "create_flink_runner_context";
 
     private static final String FLINK_RUNNER_CONTEXT_SWITCH_ACTION_CONTEXT =
-            "flink_runner_context.flink_runner_context_switch_action_context";
+            "flink_runner_context_switch_action_context";
 
-    private static final String CLOSE_FLINK_RUNNER_CONTEXT =
-            "flink_runner_context.close_flink_runner_context";
+    private static final String CLOSE_FLINK_RUNNER_CONTEXT = "close_flink_runner_context";
 
     // ========== ASYNC THREAD POOL ===========
-    private static final String CREATE_ASYNC_THREAD_POOL =
-            "flink_runner_context.create_async_thread_pool";
-    private static final String CLOSE_ASYNC_THREAD_POOL =
-            "flink_runner_context.close_async_thread_pool";
+    private static final String CREATE_ASYNC_THREAD_POOL = "create_async_thread_pool";
+    private static final String CLOSE_ASYNC_THREAD_POOL = "close_async_thread_pool";
 
     // =========== PYTHON AWAITABLE ===========
-    private static final String CALL_PYTHON_AWAITABLE = "function.call_python_awaitable";
+    private static final String RESOLVE_PYTHON_FUNCTION = "resolve_python_function";
+    private static final String CALL_PYTHON_AWAITABLE = "call_python_awaitable";
     private static final String PYTHON_AWAITABLE_VAR_NAME_PREFIX = "python_awaitable_";
     private static final AtomicLong PYTHON_AWAITABLE_VAR_ID = new AtomicLong(0);
 
     // =========== PYTHON AND JAVA OBJECT CONVERT ===========
-    private static final String CONVERT_JSON_TO_PYTHON_EVENT =
-            "python_java_utils.convert_json_to_python_event";
-    private static final String WRAP_TO_INPUT_EVENT = "python_java_utils.wrap_to_input_event";
-    private static final String GET_OUTPUT_FROM_OUTPUT_EVENT =
-            "python_java_utils.get_output_from_output_event";
+    private static final String CONVERT_JSON_TO_PYTHON_EVENT = "convert_json_to_python_event";
+    private static final String WRAP_TO_INPUT_EVENT = "wrap_to_input_event";
+    private static final String GET_OUTPUT_FROM_OUTPUT_EVENT = "get_output_from_output_event";
 
     private final PythonInterpreter interpreter;
     private final AgentPlan agentPlan;
@@ -96,22 +109,47 @@ public class PythonActionExecutor {
 
     public void open() throws Exception {
         interpreter.exec(PYTHON_IMPORTS);
+        resolveDeclaredPythonActions();
 
         pythonAsyncThreadPool =
                 (PyObject)
-                        interpreter.invoke(
+                        interpreter.invokeMethod(
+                                RUNNER_CONTEXT_MODULE,
                                 CREATE_ASYNC_THREAD_POOL,
                                 agentPlan.getConfig().get(AgentExecutionOptions.NUM_ASYNC_THREADS));
 
         pythonRunnerContext =
                 (PyObject)
-                        interpreter.invoke(
+                        interpreter.invokeMethod(
+                                RUNNER_CONTEXT_MODULE,
                                 CREATE_FLINK_RUNNER_CONTEXT,
                                 runnerContext,
                                 new ObjectMapper().writeValueAsString(agentPlan),
                                 pythonAsyncThreadPool,
                                 javaResourceAdapter,
                                 jobIdentifier);
+    }
+
+    private void resolveDeclaredPythonActions() {
+        for (org.apache.flink.agents.plan.actions.Action action : agentPlan.getActions().values()) {
+            if (!(action.getExec() instanceof PythonFunction)) {
+                continue;
+            }
+            PythonFunction function = (PythonFunction) action.getExec();
+            try {
+                interpreter.invokeMethod(
+                        FUNCTION_MODULE,
+                        RESOLVE_PYTHON_FUNCTION,
+                        function.getModule(),
+                        function.getQualName());
+            } catch (Exception e) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Could not resolve Python action %s.%s.",
+                                function.getModule(), function.getQualName()),
+                        e);
+            }
+        }
     }
 
     /**
@@ -128,12 +166,18 @@ public class PythonActionExecutor {
             throws Exception {
         runnerContext.checkNoPendingEvents();
         function.setInterpreter(interpreter);
+        function.setInvocationModule(FUNCTION_MODULE);
 
-        interpreter.invoke(
-                FLINK_RUNNER_CONTEXT_SWITCH_ACTION_CONTEXT, pythonRunnerContext, hashOfKey);
+        interpreter.invokeMethod(
+                RUNNER_CONTEXT_MODULE,
+                FLINK_RUNNER_CONTEXT_SWITCH_ACTION_CONTEXT,
+                pythonRunnerContext,
+                hashOfKey);
 
         String eventJson = new ObjectMapper().writeValueAsString(event);
-        Object pythonEventObject = interpreter.invoke(CONVERT_JSON_TO_PYTHON_EVENT, eventJson);
+        Object pythonEventObject =
+                interpreter.invokeMethod(
+                        JAVA_UTILS_MODULE, CONVERT_JSON_TO_PYTHON_EVENT, eventJson);
 
         try {
             Object calledResult = function.call(pythonEventObject, pythonRunnerContext);
@@ -156,13 +200,13 @@ public class PythonActionExecutor {
     public Event wrapToInputEvent(Object eventData) throws IOException {
         checkState(eventData instanceof byte[]);
         // wrap_to_input_event returns a JSON string
-        Object result = interpreter.invoke(WRAP_TO_INPUT_EVENT, eventData);
+        Object result = interpreter.invokeMethod(JAVA_UTILS_MODULE, WRAP_TO_INPUT_EVENT, eventData);
         checkState(result instanceof String);
         return Event.fromJson((String) result);
     }
 
     public Object getOutputFromOutputEvent(String eventJson) {
-        return interpreter.invoke(GET_OUTPUT_FROM_OUTPUT_EVENT, eventJson);
+        return interpreter.invokeMethod(JAVA_UTILS_MODULE, GET_OUTPUT_FROM_OUTPUT_EVENT, eventJson);
     }
 
     /**
@@ -182,7 +226,8 @@ public class PythonActionExecutor {
                 pythonAwaitable != null,
                 "Python awaitable '%s' not found in interpreter. ",
                 pythonAwaitableRef);
-        Object invokeResult = interpreter.invoke(CALL_PYTHON_AWAITABLE, pythonAwaitable);
+        Object invokeResult =
+                interpreter.invokeMethod(FUNCTION_MODULE, CALL_PYTHON_AWAITABLE, pythonAwaitable);
         checkState(invokeResult.getClass().isArray() && ((Object[]) invokeResult).length == 2);
         return (boolean) ((Object[]) invokeResult)[0];
     }
@@ -190,12 +235,14 @@ public class PythonActionExecutor {
     public void close() throws Exception {
         if (interpreter != null) {
             if (pythonAsyncThreadPool != null) {
-                interpreter.invoke(CLOSE_ASYNC_THREAD_POOL, pythonAsyncThreadPool);
+                interpreter.invokeMethod(
+                        RUNNER_CONTEXT_MODULE, CLOSE_ASYNC_THREAD_POOL, pythonAsyncThreadPool);
             }
 
             if (pythonRunnerContext != null) {
                 try {
-                    interpreter.invoke(CLOSE_FLINK_RUNNER_CONTEXT, pythonRunnerContext);
+                    interpreter.invokeMethod(
+                            RUNNER_CONTEXT_MODULE, CLOSE_FLINK_RUNNER_CONTEXT, pythonRunnerContext);
                 } finally {
                     pythonRunnerContext = null;
                 }

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutor.java
@@ -86,6 +86,7 @@ public class PythonActionExecutor {
     private final PythonRunnerContextImpl runnerContext;
     private final JavaResourceAdapter javaResourceAdapter;
     private final String jobIdentifier;
+    private final String moduleNamespace;
     private PyObject pythonAsyncThreadPool;
     private PyObject pythonRunnerContext;
 
@@ -94,13 +95,15 @@ public class PythonActionExecutor {
             AgentPlan agentPlan,
             JavaResourceAdapter javaResourceAdapter,
             PythonRunnerContextImpl runnerContext,
-            String jobIdentifier)
+            String jobIdentifier,
+            String moduleNamespace)
             throws JsonProcessingException {
         this.interpreter = interpreter;
         this.agentPlan = agentPlan;
         this.runnerContext = runnerContext;
         this.javaResourceAdapter = javaResourceAdapter;
         this.jobIdentifier = jobIdentifier;
+        this.moduleNamespace = moduleNamespace;
     }
 
     public PyObject getPythonRunnerContext() {
@@ -127,7 +130,8 @@ public class PythonActionExecutor {
                                 new ObjectMapper().writeValueAsString(agentPlan),
                                 pythonAsyncThreadPool,
                                 javaResourceAdapter,
-                                jobIdentifier);
+                                jobIdentifier,
+                                moduleNamespace);
     }
 
     private void resolveDeclaredPythonActions() {
@@ -141,7 +145,8 @@ public class PythonActionExecutor {
                         FUNCTION_MODULE,
                         RESOLVE_PYTHON_FUNCTION,
                         function.getModule(),
-                        function.getQualName());
+                        function.getQualName(),
+                        moduleNamespace);
             } catch (Exception e) {
                 throw new IllegalStateException(
                         String.format(
@@ -167,6 +172,7 @@ public class PythonActionExecutor {
         runnerContext.checkNoPendingEvents();
         function.setInterpreter(interpreter);
         function.setInvocationModule(FUNCTION_MODULE);
+        function.setModuleNamespace(moduleNamespace);
 
         interpreter.invokeMethod(
                 RUNNER_CONTEXT_MODULE,

--- a/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImpl.java
+++ b/runtime/src/main/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImpl.java
@@ -32,6 +32,8 @@ import org.apache.flink.agents.api.vectorstores.VectorStoreQueryResult;
 import pemja.core.PythonInterpreter;
 import pemja.core.object.PyObject;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -80,15 +82,25 @@ public class PythonResourceAdapterImpl implements PythonResourceAdapter {
     private final ResourceContext resourceContext;
     private final PythonInterpreter interpreter;
     private final JavaResourceAdapter javaResourceAdapter;
+    @Nullable private final String moduleNamespace;
     private PyObject pythonResourceContext;
 
     public PythonResourceAdapterImpl(
             ResourceContext resourceContext,
             PythonInterpreter interpreter,
             JavaResourceAdapter javaResourceAdapter) {
+        this(resourceContext, interpreter, javaResourceAdapter, null);
+    }
+
+    public PythonResourceAdapterImpl(
+            ResourceContext resourceContext,
+            PythonInterpreter interpreter,
+            JavaResourceAdapter javaResourceAdapter,
+            @Nullable String moduleNamespace) {
         this.resourceContext = resourceContext;
         this.interpreter = interpreter;
         this.javaResourceAdapter = javaResourceAdapter;
+        this.moduleNamespace = moduleNamespace;
     }
 
     public void open() {
@@ -131,7 +143,11 @@ public class PythonResourceAdapterImpl implements PythonResourceAdapter {
     @Override
     public PyObject initPythonResource(String module, String clazz, Map<String, Object> kwargs) {
         kwargs.put(RESOURCE_CONTEXT_KEY, pythonResourceContext);
-        return (PyObject) interpreter.invoke(CREATE_RESOURCE, module, clazz, kwargs);
+        if (moduleNamespace == null) {
+            return (PyObject) interpreter.invoke(CREATE_RESOURCE, module, clazz, kwargs);
+        }
+        return (PyObject)
+                interpreter.invoke(CREATE_RESOURCE, module, clazz, kwargs, moduleNamespace);
     }
 
     @Override
@@ -214,10 +230,22 @@ public class PythonResourceAdapterImpl implements PythonResourceAdapter {
     public Map<String, String> getPythonToolMetadata(
             String module, String qualName, java.util.List<String> injectedArgs) {
         @SuppressWarnings("unchecked")
-        Map<String, String> result =
-                (Map<String, String>)
-                        interpreter.invoke(
-                                GET_PYTHON_TOOL_METADATA, module, qualName, injectedArgs);
+        Map<String, String> result;
+        if (moduleNamespace == null) {
+            result =
+                    (Map<String, String>)
+                            interpreter.invoke(
+                                    GET_PYTHON_TOOL_METADATA, module, qualName, injectedArgs);
+        } else {
+            result =
+                    (Map<String, String>)
+                            interpreter.invoke(
+                                    GET_PYTHON_TOOL_METADATA,
+                                    module,
+                                    qualName,
+                                    injectedArgs,
+                                    moduleNamespace);
+        }
         if (result == null) {
             throw new IllegalStateException(
                     "Python get_python_tool_metadata returned null for " + module + ":" + qualName);
@@ -227,6 +255,9 @@ public class PythonResourceAdapterImpl implements PythonResourceAdapter {
 
     @Override
     public Object invokePythonTool(String module, String qualName, Map<String, Object> kwargs) {
-        return interpreter.invoke(INVOKE_PYTHON_TOOL, module, qualName, kwargs);
+        if (moduleNamespace == null) {
+            return interpreter.invoke(INVOKE_PYTHON_TOOL, module, qualName, kwargs);
+        }
+        return interpreter.invoke(INVOKE_PYTHON_TOOL, module, qualName, kwargs, moduleNamespace);
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
@@ -66,6 +66,7 @@ public class CompileUtilsTest {
                                 return value;
                             }
                         },
+                        "TestAgent",
                         TEST_AGENT_PLAN);
         DataStream<Long> resultStream = agentOutputStream.map(x -> (long) x + 1);
 
@@ -84,7 +85,7 @@ public class CompileUtilsTest {
 
         KeyedStream<Long, Long> keyedInputStream = env.fromData(testSequence).keyBy(x -> x);
         DataStream<Object> workflowOutputStream =
-                CompileUtils.connectToAgent(keyedInputStream, TEST_AGENT_PLAN);
+                CompileUtils.connectToAgent(keyedInputStream, "TestAgent", TEST_AGENT_PLAN);
         DataStream<Long> resultStream = workflowOutputStream.map(x -> (long) x + 1);
 
         List<Long> resultList = new ArrayList<>();

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/CompileUtilsTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.agents.runtime;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorTest;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
@@ -53,7 +55,7 @@ public class CompileUtilsTest {
 
     @Test
     void testJavaNoKeyedStreamConnectToAgent() throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamExecutionEnvironment env = createExecutionEnvironment();
 
         DataStreamSource<Long> inputStream = env.fromData(testSequence);
         DataStream<Object> agentOutputStream =
@@ -81,7 +83,7 @@ public class CompileUtilsTest {
 
     @Test
     void testJavaKeyedStreamConnectToAgent() throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamExecutionEnvironment env = createExecutionEnvironment();
 
         KeyedStream<Long, Long> keyedInputStream = env.fromData(testSequence).keyBy(x -> x);
         DataStream<Object> workflowOutputStream =
@@ -95,6 +97,16 @@ public class CompileUtilsTest {
         resultList.sort(Long::compareTo);
 
         checkResult(resultList);
+    }
+
+    private static StreamExecutionEnvironment createExecutionEnvironment() {
+        Configuration configuration = new Configuration();
+        configuration.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, 2);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+        return env;
     }
 
     private static List<Long> getTestSequence() {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/CoordinatedAgentDeploymentIsolationTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/CoordinatedAgentDeploymentIsolationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.agents.runtime;
+
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.operator.ActionExecutionOperatorTest;
+import org.apache.flink.agents.runtime.operator.CoordinatedActionExecutionOperatorFactory;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests deployment properties of the coordinated agent operator. */
+class CoordinatedAgentDeploymentIsolationTest {
+
+    private static final String AGENT_NAME = "review-agent";
+    private static final AgentPlan AGENT_PLAN =
+            ActionExecutionOperatorTest.TestAgent.getAgentPlan(false);
+
+    @Test
+    void coordinatedOperatorUsesDefaultChainingStrategy() {
+        CoordinatedActionExecutionOperatorFactory<Long, Object> factory =
+                new CoordinatedActionExecutionOperatorFactory<>(AGENT_PLAN, true);
+
+        assertThat(factory.getChainingStrategy())
+                .isEqualTo(ChainingStrategy.DEFAULT_CHAINING_STRATEGY);
+    }
+
+    @Test
+    void coordinatedOperatorDoesNotForceSlotSharingGroup() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        KeyedStream<Long, Long> input = env.fromData(1L).keyBy(value -> value);
+
+        DataStream<Object> output =
+                CompileUtils.connectToAgentWithCoordinator(input, AGENT_NAME, AGENT_PLAN);
+
+        assertThat(output.getTransformation().getUid())
+                .isEqualTo("flink-agents-coordinated-operator:" + AGENT_NAME);
+        assertThat(output.getTransformation().getName())
+                .isEqualTo("coordinated-action-execute-operator:" + AGENT_NAME);
+        assertThat(output.getTransformation().getSlotSharingGroup()).isEmpty();
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/RescalingTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/RescalingTest.java
@@ -321,6 +321,7 @@ public class RescalingTest extends TestLogger {
         input =
                 CompileUtils.connectToAgent(
                                 (KeyedStream<Integer, Integer>) input,
+                                "TestAgent",
                                 new AgentPlan(new TestAgent()))
                         .map(
                                 new MapFunction<Object, Integer>() {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtilTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/ActionStateUtilTest.java
@@ -25,11 +25,16 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test class for {@link ActionStateUtil}. */
 public class ActionStateUtilTest {
+
+    private static final String PLAN_ID_A = "a".repeat(64);
+    private static final String PLAN_ID_B = "b".repeat(64);
 
     @Test
     public void testGenerateKeyConsistency() throws Exception {
@@ -61,6 +66,50 @@ public class ActionStateUtilTest {
 
         // Keys should be different for different inputs
         assertNotEquals(key1, key2);
+    }
+
+    @Test
+    public void testUnscopedKeyKeepsFourPartFormat() throws Exception {
+        Object key = "legacy-key";
+        Action action = new NoOpAction("legacy-action");
+        InputEvent inputEvent = new InputEvent("legacy-input");
+
+        String unscopedKey = ActionStateUtil.generateKey(key, 1L, action, inputEvent);
+
+        assertEquals(4, ActionStateUtil.parseKey(unscopedKey).size());
+    }
+
+    @Test
+    public void testPlanIdSeparatesOtherwiseIdenticalKeys() throws Exception {
+        Object key = "scoped-key";
+        Action action = new NoOpAction("scoped-action");
+        InputEvent inputEvent = new InputEvent("scoped-input");
+
+        String planA = ActionStateUtil.generateKey(key, 1L, action, inputEvent, PLAN_ID_A);
+        String planB = ActionStateUtil.generateKey(key, 1L, action, inputEvent, PLAN_ID_B);
+
+        assertNotEquals(planA, planB);
+        assertEquals(PLAN_ID_A, ActionStateUtil.parseKey(planA).get(4));
+        assertEquals(PLAN_ID_B, ActionStateUtil.parseKey(planB).get(4));
+    }
+
+    @Test
+    public void testInMemoryStoreScopesStateByPlanId() throws Exception {
+        InMemoryActionStateStore store = new InMemoryActionStateStore(false);
+        Object key = "store-key";
+        Action action = new NoOpAction("store-action");
+        InputEvent inputEvent = new InputEvent("store-input");
+        ActionState state = new ActionState(inputEvent);
+
+        store.setActivePlanId(PLAN_ID_A);
+        store.put(key, 1L, action, inputEvent, state);
+        assertSame(state, store.get(key, 1L, action, inputEvent));
+
+        store.setActivePlanId(PLAN_ID_B);
+        assertNull(store.get(key, 1L, action, inputEvent));
+
+        store.setActivePlanId(PLAN_ID_A);
+        assertSame(state, store.get(key, 1L, action, inputEvent));
     }
 
     @Test

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/FlussActionStateStoreTest.java
@@ -45,6 +45,8 @@ import static org.mockito.Mockito.when;
 public class FlussActionStateStoreTest {
 
     private static final String TEST_KEY = "test-key";
+    private static final String PLAN_ID_A = "a".repeat(64);
+    private static final String PLAN_ID_B = "b".repeat(64);
 
     private AppendWriter mockWriter;
     private FlussActionStateStore store;
@@ -117,6 +119,21 @@ public class FlussActionStateStoreTest {
         assertThat(store.get(TEST_KEY, 1L, testAction, testEvent)).isNotNull();
         assertThat(store.get(TEST_KEY, 2L, testAction, testEvent)).isNotNull();
         assertThat(store.get(TEST_KEY, 3L, testAction, testEvent)).isNull();
+    }
+
+    @Test
+    void planScopesDoNotCauseDivergenceOrCleanEachOthersFutureState() throws Exception {
+        store.setActivePlanId(PLAN_ID_A);
+        store.put(TEST_KEY, 1L, testAction, testEvent, testActionState);
+        store.put(TEST_KEY, 2L, testAction, testEvent, testActionState);
+
+        store.setActivePlanId(PLAN_ID_B);
+        store.put(TEST_KEY, 1L, testAction, testEvent, testActionState);
+        assertThat(store.get(TEST_KEY, 1L, testAction, testEvent)).isSameAs(testActionState);
+
+        store.setActivePlanId(PLAN_ID_A);
+        assertThat(store.get(TEST_KEY, 1L, testAction, testEvent)).isSameAs(testActionState);
+        assertThat(store.get(TEST_KEY, 2L, testAction, testEvent)).isSameAs(testActionState);
     }
 
     // ==================== rebuildState tests ====================

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/InMemoryActionStateStore.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/InMemoryActionStateStore.java
@@ -42,12 +42,20 @@ public class InMemoryActionStateStore implements ActionStateStore {
         this.doCleanup = doCleanup;
     }
 
+    // Dynamic-plan key scope. Null keeps standalone test use unscoped.
+    private volatile String activePlanId;
+
+    @Override
+    public void setActivePlanId(String planId) {
+        this.activePlanId = planId;
+    }
+
     @Override
     public void put(Object key, long seqNum, Action action, Event event, ActionState state)
             throws IOException {
         Map<String, ActionState> actionStates =
                 keyedActionStates.getOrDefault(key.toString(), new HashMap<>());
-        actionStates.put(generateKey(key.toString(), seqNum, action, event), state);
+        actionStates.put(generateKey(key.toString(), seqNum, action, event, activePlanId), state);
         keyedActionStates.put(key.toString(), actionStates);
     }
 
@@ -55,7 +63,7 @@ public class InMemoryActionStateStore implements ActionStateStore {
     public ActionState get(Object key, long seqNum, Action action, Event event) throws IOException {
         return keyedActionStates
                 .getOrDefault(key.toString(), new HashMap<>())
-                .get(generateKey(key.toString(), seqNum, action, event));
+                .get(generateKey(key.toString(), seqNum, action, event, activePlanId));
     }
 
     @Override
@@ -73,6 +81,11 @@ public class InMemoryActionStateStore implements ActionStateStore {
     @VisibleForTesting
     public Map<String, Map<String, ActionState>> getKeyedActionStates() {
         return keyedActionStates;
+    }
+
+    @VisibleForTesting
+    public String getActivePlanId() {
+        return activePlanId;
     }
 
     @Override

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/actionstate/KafkaActionStateStoreTest.java
@@ -44,6 +44,8 @@ public class KafkaActionStateStoreTest {
 
     private static final String TEST_TOPIC = "test-action-state";
     private static final String TEST_KEY = "test-key";
+    private static final String PLAN_ID_A = "a".repeat(64);
+    private static final String PLAN_ID_B = "b".repeat(64);
 
     private MockProducer<String, ActionState> mockProducer;
     private MockConsumer<String, ActionState> mockConsumer;
@@ -134,6 +136,24 @@ public class KafkaActionStateStoreTest {
         assertNotNull(actionStateStore.get(TEST_KEY, 2L, testAction, testEvent));
         assertNull(actionStateStore.get(TEST_KEY, 3L, testAction, testEvent));
         assertNull(actionStateStore.get(TEST_KEY, 4L, testAction, testEvent));
+    }
+
+    @Test
+    void planScopesDoNotCauseDivergenceOrCleanEachOthersFutureState() throws Exception {
+        actionStateStore.setActivePlanId(PLAN_ID_A);
+        actionStateStore.put(TEST_KEY, 1L, testAction, testEvent, testActionState);
+        actionStateStore.put(TEST_KEY, 2L, testAction, testEvent, testActionState);
+
+        actionStateStore.setActivePlanId(PLAN_ID_B);
+        actionStateStore.put(TEST_KEY, 1L, testAction, testEvent, testActionState);
+        assertThat(actionStateStore.get(TEST_KEY, 1L, testAction, testEvent))
+                .isSameAs(testActionState);
+
+        actionStateStore.setActivePlanId(PLAN_ID_A);
+        assertThat(actionStateStore.get(TEST_KEY, 1L, testAction, testEvent))
+                .isSameAs(testActionState);
+        assertThat(actionStateStore.get(TEST_KEY, 2L, testAction, testEvent))
+                .isSameAs(testActionState);
     }
 
     @Test

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/client/AgentPlanClientTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/client/AgentPlanClientTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.plan.AgentConfiguration;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.CompileUtils;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateRequest;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateResponse;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AgentPlanClientTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void serializesAndStagesCompleteAgentPlan() throws Exception {
+        RestClusterClient<String> restClient = mock(RestClusterClient.class);
+        AgentPlanClient client = new AgentPlanClient(restClient);
+        JobID jobId = new JobID();
+        String agentName = "review-agent";
+        PlanUpdateResponse expected = new PlanUpdateResponse(2L, "plan-id", 3);
+        when(restClient.sendCoordinationRequest(
+                        org.mockito.ArgumentMatchers.eq(jobId),
+                        org.mockito.ArgumentMatchers.eq(
+                                CompileUtils.getCoordinatedOperatorUid(agentName)),
+                        org.mockito.ArgumentMatchers.any(PlanUpdateRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(expected));
+        AgentPlan plan =
+                new AgentPlan(
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        new AgentConfiguration());
+
+        AgentPlanClient.UpdateResult actual = client.updateAgentPlan(jobId, agentName, plan);
+
+        assertThat(actual.getPlanVersion()).isEqualTo(2L);
+        assertThat(actual.getPlanId()).isEqualTo("plan-id");
+        assertThat(actual.getRegisteredSubtasks()).isEqualTo(3);
+        ArgumentCaptor<PlanUpdateRequest> requestCaptor =
+                ArgumentCaptor.forClass(PlanUpdateRequest.class);
+        verify(restClient)
+                .sendCoordinationRequest(
+                        org.mockito.ArgumentMatchers.eq(jobId),
+                        org.mockito.ArgumentMatchers.eq(
+                                CompileUtils.getCoordinatedOperatorUid(agentName)),
+                        requestCaptor.capture());
+        AgentPlan decoded =
+                OBJECT_MAPPER.readValue(requestCaptor.getValue().agentPlanJson, AgentPlan.class);
+        assertThat(decoded.getActions()).isEmpty();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void stringBridgeReturnsOnlyPlanUpdateResponses() {
+        RestClusterClient<String> restClient = mock(RestClusterClient.class);
+        AgentPlanClient client = new AgentPlanClient(restClient);
+        JobID jobId = new JobID();
+        CoordinationResponse unexpected = mock(CoordinationResponse.class);
+        when(restClient.sendCoordinationRequest(
+                        org.mockito.ArgumentMatchers.eq(jobId),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any(PlanUpdateRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(unexpected));
+
+        assertThatThrownBy(
+                        () ->
+                                client.updateAgentPlan(
+                                        jobId.toHexString(), "review-agent", emptyPlanJson()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("PlanUpdateResponse");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void rejectsBlankAgentNameBeforeSending() {
+        RestClusterClient<String> restClient = mock(RestClusterClient.class);
+        AgentPlanClient client = new AgentPlanClient(restClient);
+
+        assertThatThrownBy(
+                        () ->
+                                client.updateAgentPlan(
+                                        new JobID().toHexString(), " ", emptyPlanJson()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("agent name");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void closesUnderlyingRestClient() throws Exception {
+        RestClusterClient<String> restClient = mock(RestClusterClient.class);
+        AgentPlanClient client = new AgentPlanClient(restClient);
+
+        client.close();
+
+        verify(restClient).close();
+    }
+
+    @Test
+    void rejectsBlankRestAddress() {
+        assertThatThrownBy(() -> new AgentPlanClient(" ", 8081))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("REST address");
+    }
+
+    @Test
+    void rejectsInvalidRestPort() {
+        assertThatThrownBy(() -> new AgentPlanClient("localhost", 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("REST port");
+        assertThatThrownBy(() -> new AgentPlanClient("localhost", 65536))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("REST port");
+    }
+
+    private static String emptyPlanJson() throws Exception {
+        return OBJECT_MAPPER.writeValueAsString(
+                new AgentPlan(
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        new HashMap<>(),
+                        new AgentConfiguration()));
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtilsTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/client/CoordinationRequestUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.client;
+
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateRequest;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CoordinationRequestUtilsTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void sendsRequestUsingOperatorUidOnFlinkTwo() {
+        RestClusterClient<String> restClient = mock(RestClusterClient.class);
+        JobID jobId = new JobID();
+        String operatorUid = "flink-agents-coordinated-operator:review-agent";
+        PlanUpdateRequest request = new PlanUpdateRequest("{}");
+        CompletableFuture<CoordinationResponse> expected = new CompletableFuture<>();
+        when(restClient.sendCoordinationRequest(jobId, operatorUid, request)).thenReturn(expected);
+
+        CompletableFuture<CoordinationResponse> actual =
+                CoordinationRequestUtils.send(restClient, jobId, operatorUid, request);
+
+        assertThat(actual).isSameAs(expected);
+        verify(restClient).sendCoordinationRequest(jobId, operatorUid, request);
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/env/RemoteExecutionEnvironmentTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/env/RemoteExecutionEnvironmentTest.java
@@ -17,9 +17,12 @@
  */
 package org.apache.flink.agents.runtime.env;
 
+import org.apache.flink.agents.api.AgentBuilder;
 import org.apache.flink.agents.api.AgentsExecutionEnvironment;
+import org.apache.flink.agents.api.agents.Agent;
 import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -95,4 +98,83 @@ public class RemoteExecutionEnvironmentTest {
 
         verify(flinkEnv).execute(customJobName);
     }
+
+    @Test
+    void applyUsesAgentSimpleClassNameAsDeploymentName() {
+        StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(flinkEnv);
+
+        DataStream<Object> output =
+                agentsEnv
+                        .fromDataStream(flinkEnv.fromData(1L).keyBy(value -> value))
+                        .apply(new NamedAgent())
+                        .toDataStream();
+
+        assertDeploymentIdentity(output, "NamedAgent");
+    }
+
+    @Test
+    void applyAllowsExplicitDeploymentName() {
+        StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(flinkEnv);
+
+        DataStream<Object> output =
+                agentsEnv
+                        .fromDataStream(flinkEnv.fromData(1L).keyBy(value -> value))
+                        .apply("review-agent", new NamedAgent())
+                        .toDataStream();
+
+        assertDeploymentIdentity(output, "review-agent");
+    }
+
+    @Test
+    void applyRegisteredAgentUsesRegistryNameAsDeploymentName() {
+        StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        AgentsExecutionEnvironment agentsEnv =
+                AgentsExecutionEnvironment.getExecutionEnvironment(flinkEnv);
+        agentsEnv.getAgents().put("yaml-agent", new NamedAgent());
+
+        DataStream<Object> output =
+                agentsEnv
+                        .fromDataStream(flinkEnv.fromData(1L).keyBy(value -> value))
+                        .apply("yaml-agent")
+                        .toDataStream();
+
+        assertDeploymentIdentity(output, "yaml-agent");
+    }
+
+    @Test
+    void applyRejectsBlankExplicitDeploymentName() {
+        StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        AgentBuilder builder =
+                AgentsExecutionEnvironment.getExecutionEnvironment(flinkEnv)
+                        .fromDataStream(flinkEnv.fromData(1L).keyBy(value -> value));
+
+        assertThatThrownBy(() -> builder.apply("  ", new NamedAgent()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("agent name");
+    }
+
+    @Test
+    void applyRejectsAnonymousAgentWithoutExplicitDeploymentName() {
+        StreamExecutionEnvironment flinkEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+        AgentBuilder builder =
+                AgentsExecutionEnvironment.getExecutionEnvironment(flinkEnv)
+                        .fromDataStream(flinkEnv.fromData(1L).keyBy(value -> value));
+
+        assertThatThrownBy(() -> builder.apply(new Agent() {}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("explicit agent name");
+    }
+
+    private static void assertDeploymentIdentity(DataStream<Object> output, String agentName) {
+        assertThat(output.getTransformation().getUid())
+                .isEqualTo("flink-agents-coordinated-operator:" + agentName);
+        assertThat(output.getTransformation().getName())
+                .isEqualTo("coordinated-action-execute-operator:" + agentName);
+    }
+
+    private static final class NamedAgent extends Agent {}
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/memory/ShortTermMemoryTTLIntegrationTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/memory/ShortTermMemoryTTLIntegrationTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.agents.api.annotation.Action;
 import org.apache.flink.agents.api.context.MemoryObject;
 import org.apache.flink.agents.api.context.RunnerContext;
 import org.apache.flink.agents.plan.AgentConfiguration;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
@@ -123,7 +125,11 @@ class ShortTermMemoryTTLIntegrationTest {
     private static List<String> runScenario(
             long ttlMs, long sleepMs, boolean configureTtlMs, boolean configureTtlOptions)
             throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration configuration = new Configuration();
+        configuration.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, 2);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
         env.setParallelism(1);
 
         AgentsExecutionEnvironment agentEnv =

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionExecutionOperatorTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.agents.runtime.actionstate.ActionState;
 import org.apache.flink.agents.runtime.actionstate.CallResult;
 import org.apache.flink.agents.runtime.actionstate.InMemoryActionStateStore;
 import org.apache.flink.agents.runtime.eventlog.FileEventLogger;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanIds;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -2116,6 +2117,8 @@ public class ActionExecutionOperatorTest {
             String actionName,
             ActionState actionState)
             throws Exception {
+        actionStateStore.setActivePlanId(
+                PlanIds.planIdOf(PlanVersionManager.canonicalJsonOf(agentPlan)));
         InputEvent event = new InputEvent(input);
         Action action = agentPlan.getActions().get(actionName);
         actionStateStore.put(key, 0L, action, event, actionState);

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/ActionTaskContextManagerTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.agents.runtime.operator;
 
 import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.ResourceCache;
@@ -222,6 +223,42 @@ class ActionTaskContextManagerTest {
         mgr.close();
     }
 
+    @Test
+    void resetForPlanSwitchReleasesTheOldRunnerContext() throws Exception {
+        try (ActionTaskContextManager mgr = new ActionTaskContextManager(1)) {
+            AgentPlan oldPlan = planWithMarker("old");
+            AgentPlan newPlan = planWithMarker("new");
+            ResourceCache oldCache = mock(ResourceCache.class);
+            ResourceCache newCache = mock(ResourceCache.class);
+
+            RunnerContextImpl oldContext =
+                    mgr.createOrGetRunnerContext(
+                            true,
+                            oldPlan,
+                            oldCache,
+                            mock(FlinkAgentsMetricGroupImpl.class, RETURNS_DEEP_STUBS),
+                            "job",
+                            () -> {},
+                            null,
+                            null);
+
+            mgr.resetForPlanSwitch();
+
+            RunnerContextImpl newContext =
+                    mgr.createOrGetRunnerContext(
+                            true,
+                            newPlan,
+                            newCache,
+                            mock(FlinkAgentsMetricGroupImpl.class, RETURNS_DEEP_STUBS),
+                            "job",
+                            () -> {},
+                            null,
+                            null);
+            assertThat(newContext).isNotSameAs(oldContext);
+            assertThat(newContext.getConfig().getStr("plan-marker", null)).isEqualTo("new");
+        }
+    }
+
     /**
      * Shared helper: install a runner context on {@code task} using mocked collaborators. Used by
      * tests that need a fully wired runner context but do not care about the collaborator details.
@@ -251,5 +288,11 @@ class ActionTaskContextManagerTest {
 
     private static AgentPlan newEmptyAgentPlan() {
         return new AgentPlan(new HashMap<>(), new HashMap<>());
+    }
+
+    private static AgentPlan planWithMarker(String marker) {
+        AgentConfiguration config = new AgentConfiguration();
+        config.setStr("plan-marker", marker);
+        return new AgentPlan(new HashMap<>(), new HashMap<>(), new HashMap<>(), config);
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -343,7 +343,7 @@ public class DynamicPlanSwitchOperatorTest {
     }
 
     @Test
-    void updateConfigIsPinnedToBootstrapPlan(@TempDir Path tempDir) throws Exception {
+    void updateConfigIsPinnedToBootstrapPlan() throws Exception {
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
             harness.open();
             ActionExecutionOperator<Long, Object> op = op(harness);
@@ -352,21 +352,15 @@ public class DynamicPlanSwitchOperatorTest {
             newPlan.getConfig().setStr("job-identifier", "attempted-override");
             newPlan.getConfig().setInt("num-async-threads", 1);
             newPlan.getConfig().setStr("update-only-key", "ignored");
-            Path artifact = writeJavaArtifact(tempDir.resolve("plan-v1.jar"), "v1");
-            configureJavaArtifact(newPlan, artifact);
             op.handleOperatorEvent(planUpdate(1L, json(newPlan)));
             checkpoint(harness, 1L);
 
-            // Job-level configuration is pinned at submission; artifact coordinates are the
-            // plan-scoped exception.
+            // Job-level configuration is pinned at submission. Java artifact coordinates are the
+            // only plan-scoped exception in this layer and are covered by the tests below.
             AgentConfiguration effective = op.getCurrentPlanForTesting().getConfig();
             assertThat(effective.getStr("job-identifier", null)).isNull();
             assertThat(effective.getInt("num-async-threads", -1)).isEqualTo(-1);
             assertThat(effective.getStr("update-only-key", null)).isNull();
-            assertThat(effective.getStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, null))
-                    .isEqualTo(artifact.toString());
-            assertThat(effective.getStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, null))
-                    .isEqualTo(PlanIds.sha256HexOfFile(artifact));
         }
     }
 
@@ -528,22 +522,77 @@ public class DynamicPlanSwitchOperatorTest {
     }
 
     @Test
-    void pythonArtifactTamperedAfterPrepareFailsAtTheActivationBarrier(@TempDir Path tempDir)
+    void pythonArtifactIsPreparedAfterDrainAndUsesVersionedDependencyGraph(@TempDir Path tempDir)
             throws Exception {
-        Path artifact = writePythonArtifact(tempDir.resolve("agent-v2.zip"));
+        Path artifactV1 = createPythonPackageArtifact(tempDir.resolve("v1"), 100L);
+        Path artifactV2 = createPythonPackageArtifact(tempDir.resolve("v2"), 200L);
 
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
-                harness(pythonPlan("old_action"))) {
+                pythonArtifactHarness(artifactV1)) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+            PythonBridgeManager bridge = pythonBridge(op);
+            PythonActionExecutor oldExecutor = bridge.getPythonActionExecutor();
+
+            op.handleOperatorEvent(planUpdate(1L, json(pythonArtifactPlan(artifactV2))));
+
+            // Receiving an update must not load V2 user modules: V1 still serves records until
+            // the activation barrier.
+            assertThat(bridge.getPythonActionExecutor()).isSameAs(oldExecutor);
+            harness.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("101");
+
+            checkpoint(harness, 101L);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+            assertThat(bridge.getPythonActionExecutor()).isNotSameAs(oldExecutor);
+
+            harness.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+            // Both app.agent and its already-imported dependency must now resolve from V2.
+            assertThat(outputs(harness)).containsExactly("101", "201");
+        }
+    }
+
+    @Test
+    void missingPythonActionEntryFailsAtTheActivationBarrier(@TempDir Path tempDir)
+            throws Exception {
+        Path artifactV1 = createPythonPackageArtifact(tempDir.resolve("v1"), 100L);
+        Path artifactV2 = createPythonPackageArtifact(tempDir.resolve("v2"), 200L);
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                pythonArtifactHarness(artifactV1)) {
             harness.open();
             ActionExecutionOperator<Long, Object> op = op(harness);
 
-            op.handleOperatorEvent(planUpdate(1L, json(pythonArtifactPlan(artifact))));
+            op.handleOperatorEvent(
+                    planUpdate(1L, json(pythonArtifactPlan(artifactV2, "app.missing_action"))));
             assertThat(op.hasPendingPlanForTesting()).isTrue();
-            Files.writeString(artifact, "tampered after prepare");
 
-            assertThatThrownBy(() -> checkpoint(harness, 1L))
+            assertThatThrownBy(() -> checkpoint(harness, 101L))
+                    .hasMessageContaining("Could not resolve Python action")
+                    .hasMessageContaining("app.missing_action.handle");
+        }
+    }
+
+    @Test
+    void pythonArtifactTamperedAfterPrepareFailsAtTheActivationBarrier(@TempDir Path tempDir)
+            throws Exception {
+        Path artifactV1 = createPythonPackageArtifact(tempDir.resolve("v1"), 100L);
+        Path artifactV2 = createPythonPackageArtifact(tempDir.resolve("v2"), 200L);
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                pythonArtifactHarness(artifactV1)) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            op.handleOperatorEvent(planUpdate(1L, json(pythonArtifactPlan(artifactV2))));
+            assertThat(op.hasPendingPlanForTesting()).isTrue();
+            Files.writeString(artifactV2, "tampered after prepare");
+
+            assertThatThrownBy(() -> checkpoint(harness, 101L))
                     .hasMessageContaining("failed sha256 verification")
-                    .hasMessageContaining(artifact.toString());
+                    .hasMessageContaining(artifactV2.toString());
         }
     }
 
@@ -655,10 +704,21 @@ public class DynamicPlanSwitchOperatorTest {
                 TypeInformation.of(Long.class));
     }
 
+    private static KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> pythonArtifactHarness(
+            Path artifactPath) throws Exception {
+        return harness(pythonArtifactPlan(artifactPath));
+    }
+
     private static KeyedOneInputStreamOperatorTestHarness<Long, Row, Object> pythonWireHarness()
             throws Exception {
+        AgentPlan bootstrapPlan = singleActionPlan("oldAction");
+        bootstrapPlan
+                .getConfig()
+                .setStr(
+                        PythonBridgeManager.PYTHON_RUNTIME_PATH_CONFIG,
+                        pythonRuntimePath().toString());
         return new KeyedOneInputStreamOperatorTestHarness<>(
-                new ActionExecutionOperatorFactory<>(singleActionPlan("oldAction"), false),
+                new ActionExecutionOperatorFactory<>(bootstrapPlan, false),
                 (KeySelector<Row, Long>) value -> 0L,
                 TypeInformation.of(Long.class));
     }
@@ -760,15 +820,82 @@ public class DynamicPlanSwitchOperatorTest {
                 config);
     }
 
-    private static AgentPlan pythonArtifactPlan(Path artifact) throws Exception {
-        AgentPlan plan = pythonPlan("new_action");
-        plan.getConfig()
-                .setStr(PythonBridgeManager.PYTHON_ARTIFACT_PATH_CONFIG, artifact.toString());
-        plan.getConfig()
-                .setStr(
-                        PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG,
-                        PlanIds.sha256HexOfFile(artifact));
-        return plan;
+    private static AgentPlan pythonArtifactPlan(Path artifactPath) throws Exception {
+        return pythonArtifactPlan(artifactPath, "app.agent");
+    }
+
+    private static AgentPlan pythonArtifactPlan(Path artifactPath, String module) throws Exception {
+        Action action =
+                new Action(
+                        "pythonAction",
+                        new PythonFunction(module, "handle"),
+                        Collections.singletonList(InputEvent.EVENT_TYPE));
+        AgentConfiguration config = new AgentConfiguration();
+        config.setInt("num-async-threads", 1);
+        config.setStr(PythonBridgeManager.PYTHON_ARTIFACT_PATH_CONFIG, artifactPath.toString());
+        config.setStr(
+                PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG,
+                PlanIds.sha256HexOfFile(artifactPath));
+        config.setStr(
+                PythonBridgeManager.PYTHON_RUNTIME_PATH_CONFIG, pythonRuntimePath().toString());
+        return new AgentPlan(
+                Map.of(action.getName(), action),
+                Map.of(InputEvent.EVENT_TYPE, List.of(action)),
+                new HashMap<>(),
+                config);
+    }
+
+    private static Path createPythonPackageArtifact(Path directory, long addend) throws Exception {
+        Files.createDirectories(directory);
+        Path artifact = directory.resolve("app-" + addend + ".zip");
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(artifact))) {
+            writeZipEntry(zip, "app/__init__.py", "");
+            writeZipEntry(zip, "app/utils/__init__.py", "");
+            writeZipEntry(zip, "app/utils/data_type.py", "ADDEND = " + addend + "\n");
+            writeZipEntry(
+                    zip,
+                    "app/tools.py",
+                    "from app.utils import data_type\n\n"
+                            + "TOOL_VERSION = "
+                            + addend
+                            + "\n\n"
+                            + "def add(value):\n"
+                            + "    if TOOL_VERSION != data_type.ADDEND:\n"
+                            + "        raise RuntimeError('mixed tool and dependency versions')\n"
+                            + "    return value + data_type.ADDEND\n");
+            writeZipEntry(
+                    zip,
+                    "app/agent.py",
+                    "from app.tools import add\n"
+                            + "from flink_agents.api.events.event import Event, InputEvent, OutputEvent\n"
+                            + "from flink_agents.api.runner_context import RunnerContext\n\n"
+                            + "ACTION_VERSION = "
+                            + addend
+                            + "\n\n"
+                            + "def handle(event: Event, ctx: RunnerContext):\n"
+                            + "    input_value = InputEvent.from_event(event).input\n"
+                            + "    value = add(input_value)\n"
+                            + "    if value - input_value != ACTION_VERSION:\n"
+                            + "        raise RuntimeError('mixed action and tool versions')\n"
+                            + "    ctx.send_event(OutputEvent(output=str(value)))\n");
+        }
+        return artifact;
+    }
+
+    private static void writeZipEntry(ZipOutputStream zip, String name, String contents)
+            throws Exception {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(contents.getBytes(StandardCharsets.UTF_8));
+        zip.closeEntry();
+    }
+
+    private static Path pythonRuntimePath() {
+        Path workingDirectory = Path.of("").toAbsolutePath().normalize();
+        Path fromRepositoryRoot = workingDirectory.resolve("python");
+        if (Files.exists(fromRepositoryRoot)) {
+            return fromRepositoryRoot;
+        }
+        return workingDirectory.resolve("..").resolve("python").normalize();
     }
 
     private static AgentPlan javaArtifactPlan(Path artifactPath) throws Exception {
@@ -879,15 +1006,6 @@ public class DynamicPlanSwitchOperatorTest {
             jar.putNextEntry(new JarEntry("marker.txt"));
             jar.write(marker.getBytes(StandardCharsets.UTF_8));
             jar.closeEntry();
-        }
-        return artifact;
-    }
-
-    private static Path writePythonArtifact(Path artifact) throws Exception {
-        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(artifact))) {
-            zip.putNextEntry(new ZipEntry("app/agent.py"));
-            zip.write("def handle(value):\n    return value\n".getBytes(StandardCharsets.UTF_8));
-            zip.closeEntry();
         }
         return artifact;
     }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -40,12 +40,18 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -329,7 +335,7 @@ public class DynamicPlanSwitchOperatorTest {
     }
 
     @Test
-    void updateConfigIsPinnedToBootstrapPlan() throws Exception {
+    void updateConfigIsPinnedToBootstrapPlan(@TempDir Path tempDir) throws Exception {
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
             harness.open();
             ActionExecutionOperator<Long, Object> op = op(harness);
@@ -338,10 +344,8 @@ public class DynamicPlanSwitchOperatorTest {
             newPlan.getConfig().setStr("job-identifier", "attempted-override");
             newPlan.getConfig().setInt("num-async-threads", 1);
             newPlan.getConfig().setStr("update-only-key", "ignored");
-            newPlan.getConfig()
-                    .setStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, "/tmp/plan-v1.jar");
-            newPlan.getConfig()
-                    .setStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, "artifact-digest");
+            Path artifact = writeJavaArtifact(tempDir.resolve("plan-v1.jar"), "v1");
+            configureJavaArtifact(newPlan, artifact);
             op.handleOperatorEvent(planUpdate(1L, json(newPlan)));
             checkpoint(harness, 1L);
 
@@ -352,9 +356,85 @@ public class DynamicPlanSwitchOperatorTest {
             assertThat(effective.getInt("num-async-threads", -1)).isEqualTo(-1);
             assertThat(effective.getStr("update-only-key", null)).isNull();
             assertThat(effective.getStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, null))
-                    .isEqualTo("/tmp/plan-v1.jar");
+                    .isEqualTo(artifact.toString());
             assertThat(effective.getStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, null))
-                    .isEqualTo("artifact-digest");
+                    .isEqualTo(PlanIds.sha256HexOfFile(artifact));
+        }
+    }
+
+    @Test
+    void javaArtifactPathAndShaMustBeConfiguredTogether(@TempDir Path tempDir) throws Exception {
+        Path artifact = writeJavaArtifact(tempDir.resolve("user-actions.jar"), "v1");
+
+        AgentPlan pathOnly = singleActionPlan("newAction");
+        pathOnly.getConfig()
+                .setStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, artifact.toString());
+        AgentPlan shaOnly = singleActionPlan("newAction");
+        shaOnly.getConfig()
+                .setStr(
+                        PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG,
+                        PlanIds.sha256HexOfFile(artifact));
+
+        for (AgentPlan invalidPlan : List.of(pathOnly, shaOnly)) {
+            try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+                harness.open();
+                ActionExecutionOperator<Long, Object> op = op(harness);
+
+                assertThatThrownBy(() -> op.handleOperatorEvent(planUpdate(1L, json(invalidPlan))))
+                        .hasMessageContaining("must be configured together");
+
+                assertThat(op.hasPendingPlanForTesting()).isFalse();
+                assertThat(op.getCurrentPlanVersionForTesting()).isZero();
+            }
+        }
+    }
+
+    @Test
+    void javaArtifactTamperedAfterPrepareFailsAtTheActivationBarrier(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = writeJavaArtifact(tempDir.resolve("user-actions.jar"), "v1");
+        AgentPlan newPlan = javaArtifactPlan(artifact);
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            op.handleOperatorEvent(planUpdate(1L, json(newPlan)));
+            assertThat(op.hasPendingPlanForTesting()).isTrue();
+            writeJavaArtifact(artifact, "tampered-after-prepare");
+
+            assertThatThrownBy(() -> checkpoint(harness, 1L))
+                    .hasMessageContaining("failed sha256 verification")
+                    .hasMessageContaining(artifact.toString());
+        }
+    }
+
+    @Test
+    void javaArtifactCannotChangeDigestAtTheSamePath(@TempDir Path tempDir) throws Exception {
+        Path artifact = writeJavaArtifact(tempDir.resolve("user-actions.jar"), "v1");
+        AgentPlan versionOne = javaArtifactPlan(artifact);
+        String versionOneDigest =
+                versionOne.getConfig().getStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, null);
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+            op.handleOperatorEvent(planUpdate(1L, json(versionOne)));
+            checkpoint(harness, 1L);
+
+            writeJavaArtifact(artifact, "v2");
+            AgentPlan versionTwo = javaArtifactPlan(artifact);
+            assertThat(
+                            versionTwo
+                                    .getConfig()
+                                    .getStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, null))
+                    .isNotEqualTo(versionOneDigest);
+
+            assertThatThrownBy(() -> op.handleOperatorEvent(planUpdate(2L, json(versionTwo))))
+                    .hasMessageContaining("is immutable");
+
+            assertThat(op.hasPendingPlanForTesting()).isFalse();
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
         }
     }
 
@@ -559,5 +639,29 @@ public class DynamicPlanSwitchOperatorTest {
                 Map.of(InputEvent.EVENT_TYPE, List.of(action)),
                 new HashMap<>(),
                 config);
+    }
+
+    private static AgentPlan javaArtifactPlan(Path artifactPath) throws Exception {
+        AgentPlan plan = singleActionPlan("newAction");
+        configureJavaArtifact(plan, artifactPath);
+        return plan;
+    }
+
+    private static void configureJavaArtifact(AgentPlan plan, Path artifactPath) throws Exception {
+        plan.getConfig()
+                .setStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, artifactPath.toString());
+        plan.getConfig()
+                .setStr(
+                        PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG,
+                        PlanIds.sha256HexOfFile(artifactPath));
+    }
+
+    private static Path writeJavaArtifact(Path artifact, String marker) throws Exception {
+        try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(artifact))) {
+            jar.putNextEntry(new JarEntry("marker.txt"));
+            jar.write(marker.getBytes(StandardCharsets.UTF_8));
+            jar.closeEntry();
+        }
+        return artifact;
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -59,6 +59,8 @@ import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -526,6 +528,26 @@ public class DynamicPlanSwitchOperatorTest {
     }
 
     @Test
+    void pythonArtifactTamperedAfterPrepareFailsAtTheActivationBarrier(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = writePythonArtifact(tempDir.resolve("agent-v2.zip"));
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                harness(pythonPlan("old_action"))) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            op.handleOperatorEvent(planUpdate(1L, json(pythonArtifactPlan(artifact))));
+            assertThat(op.hasPendingPlanForTesting()).isTrue();
+            Files.writeString(artifact, "tampered after prepare");
+
+            assertThatThrownBy(() -> checkpoint(harness, 1L))
+                    .hasMessageContaining("failed sha256 verification")
+                    .hasMessageContaining(artifact.toString());
+        }
+    }
+
+    @Test
     void existingPythonActionCanSwitchWithoutAnArtifact() throws Exception {
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
                 harness(pythonPlan("old_action"))) {
@@ -738,6 +760,17 @@ public class DynamicPlanSwitchOperatorTest {
                 config);
     }
 
+    private static AgentPlan pythonArtifactPlan(Path artifact) throws Exception {
+        AgentPlan plan = pythonPlan("new_action");
+        plan.getConfig()
+                .setStr(PythonBridgeManager.PYTHON_ARTIFACT_PATH_CONFIG, artifact.toString());
+        plan.getConfig()
+                .setStr(
+                        PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG,
+                        PlanIds.sha256HexOfFile(artifact));
+        return plan;
+    }
+
     private static AgentPlan javaArtifactPlan(Path artifactPath) throws Exception {
         AgentPlan plan = singleActionPlan("newAction");
         configureJavaArtifact(plan, artifactPath);
@@ -846,6 +879,15 @@ public class DynamicPlanSwitchOperatorTest {
             jar.putNextEntry(new JarEntry("marker.txt"));
             jar.write(marker.getBytes(StandardCharsets.UTF_8));
             jar.closeEntry();
+        }
+        return artifact;
+    }
+
+    private static Path writePythonArtifact(Path artifact) throws Exception {
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(artifact))) {
+            zip.putNextEntry(new ZipEntry("app/agent.py"));
+            zip.write("def handle(value):\n    return value\n".getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
         }
         return artifact;
     }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -1,0 +1,432 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.OutputEvent;
+import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.plan.AgentConfiguration;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.PythonFunction;
+import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanIds;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateEvent;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the checkpoint-aligned plan switch of {@link ActionExecutionOperator}: an update received
+ * from the coordinator is held as pending, every record before the checkpoint barrier is processed
+ * by the old plan, the switch happens at {@code prepareSnapshotPreBarrier} after draining in-flight
+ * chains, and the snapshot records the switched plan.
+ */
+public class DynamicPlanSwitchOperatorTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void updateIsHeldUntilCheckpointAndSwitchesAtBarrier() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            harness.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("old:1");
+
+            op.handleOperatorEvent(planUpdate(1L, json(singleActionPlan("newAction"))));
+            assertThat(op.hasPendingPlanForTesting()).isTrue();
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(0L);
+
+            // Records before the barrier still run on the old plan.
+            harness.processElement(new StreamRecord<>(2L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("old:1", "old:2");
+
+            // The barrier: prepareSnapshotPreBarrier drains and switches, the snapshot
+            // records the new plan.
+            checkpoint(harness, 1L);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+            assertThat(op.hasPendingPlanForTesting()).isFalse();
+            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("action");
+
+            harness.processElement(new StreamRecord<>(3L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("old:1", "old:2", "new:3");
+        }
+    }
+
+    @Test
+    void barrierDrainsInFlightChainsOnTheOldPlanBeforeSwitching() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            // Admit two records (distinct keys) without running their action mails, then make an
+            // update pending: the barrier must finish both chains on the old plan first.
+            harness.processElement(new StreamRecord<>(7L));
+            harness.processElement(new StreamRecord<>(8L));
+            op.handleOperatorEvent(planUpdate(1L, json(singleActionPlan("newAction"))));
+
+            checkpoint(harness, 1L);
+
+            assertThat(outputs(harness)).containsExactlyInAnyOrder("old:7", "old:8");
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+
+            harness.processElement(new StreamRecord<>(9L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).contains("new:9");
+        }
+    }
+
+    @Test
+    void snapshotOfTheSwitchCheckpointRestoresTheNewPlan() throws Exception {
+        String newPlanJson = json(singleActionPlan("newAction"));
+        OperatorSubtaskState snapshot;
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+            op.handleOperatorEvent(planUpdate(1L, newPlanJson));
+            // The switch happens at this snapshot's barrier, so this very checkpoint already
+            // contains the new plan (with an empty in-flight set).
+            snapshot = checkpoint(harness, 1L);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+        }
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restored = harness()) {
+            restored.initializeState(snapshot);
+            restored.open();
+            ActionExecutionOperator<Long, Object> op = op(restored);
+
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("action");
+
+            restored.processElement(new StreamRecord<>(4L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(restored)).containsExactly("new:4");
+        }
+    }
+
+    @Test
+    void restoreWithoutSwitchKeepsBootstrapPlanUntilUpdateIsResubmitted() throws Exception {
+        String newPlanJson = json(singleActionPlan("newAction"));
+        OperatorSubtaskState snapshot;
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            // Snapshot before any update: the bootstrap plan is in effect and nothing is written.
+            snapshot = checkpoint(harness, 1L);
+        }
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restored = harness()) {
+            restored.initializeState(snapshot);
+            restored.open();
+            ActionExecutionOperator<Long, Object> op = op(restored);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(0L);
+
+            // The volatile candidate was discarded by recovery. A client resubmission is a fresh
+            // pending update and switches at the next checkpoint.
+            op.handleOperatorEvent(planUpdate(1L, newPlanJson));
+            assertThat(op.hasPendingPlanForTesting()).isTrue();
+            checkpoint(restored, 2L);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void staleOrDuplicateDeliveryIsIgnored() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            String newPlanJson = json(singleActionPlan("newAction"));
+            op.handleOperatorEvent(planUpdate(1L, newPlanJson));
+            checkpoint(harness, 1L);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+
+            // Re-delivery of the switched plan must not create pending work; neither must an older
+            // version.
+            op.handleOperatorEvent(planUpdate(1L, newPlanJson));
+            assertThat(op.hasPendingPlanForTesting()).isFalse();
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
+        }
+    }
+
+    @Test
+    void newestPendingWinsBeforeTheSwitch() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            op.handleOperatorEvent(planUpdate(1L, json(singleActionPlan("newAction"))));
+            op.handleOperatorEvent(planUpdate(2L, json(singleActionPlan("newerAction"))));
+
+            checkpoint(harness, 1L);
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(2L);
+            harness.processElement(new StreamRecord<>(10L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("newer:10");
+        }
+    }
+
+    @Test
+    void localPrepareFailureIsRethrownAfterPendingIsDiscarded() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            assertThatThrownBy(() -> op.handleOperatorEvent(planUpdate(1L, "{not-a-plan")))
+                    .hasRootCauseInstanceOf(JsonParseException.class);
+            assertThat(op.hasPendingPlanForTesting()).isFalse();
+            assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(0L);
+        }
+    }
+
+    @Test
+    void updateConfigIsPinnedToBootstrapPlan() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            AgentPlan newPlan = singleActionPlan("newAction");
+            newPlan.getConfig().setStr("job-identifier", "attempted-override");
+            newPlan.getConfig().setInt("num-async-threads", 1);
+            newPlan.getConfig().setStr("update-only-key", "ignored");
+            op.handleOperatorEvent(planUpdate(1L, json(newPlan)));
+            checkpoint(harness, 1L);
+
+            // Job-level configuration is pinned at submission; only the update's plan structure
+            // (actions, routing and resources) is applied.
+            AgentConfiguration effective = op.getCurrentPlanForTesting().getConfig();
+            assertThat(effective.getStr("job-identifier", null)).isNull();
+            assertThat(effective.getInt("num-async-threads", -1)).isEqualTo(-1);
+            assertThat(effective.getStr("update-only-key", null)).isNull();
+        }
+    }
+
+    @Test
+    void existingPythonActionCanSwitchWithoutAnArtifact() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                harness(pythonPlan("old_action"))) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+            PythonBridgeManager bridge = pythonBridge(op);
+            PythonActionExecutor oldExecutor = bridge.getPythonActionExecutor();
+
+            harness.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("python-old:1");
+
+            op.handleOperatorEvent(planUpdate(1L, json(pythonPlan("new_action"))));
+            assertThat(bridge.getPythonActionExecutor()).isSameAs(oldExecutor);
+
+            checkpoint(harness, 1L);
+            assertThat(bridge.getPythonActionExecutor()).isNotSameAs(oldExecutor);
+
+            harness.processElement(new StreamRecord<>(2L));
+            op.waitInFlightEventsFinished();
+            assertThat(outputs(harness)).containsExactly("python-old:1", "python-new:2");
+        }
+    }
+
+    @Test
+    void javaOnlyPlansKeepThePythonWireBridgeAcrossSwitch() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Row, Object> harness =
+                pythonWireHarness()) {
+            harness.open();
+            ActionExecutionOperator<Row, Object> op = rowOp(harness);
+            PythonBridgeManager bridge = pythonBridge(op);
+            PythonActionExecutor oldExecutor = bridge.getPythonActionExecutor();
+
+            assertThat(oldExecutor).isNotNull();
+
+            op.handleOperatorEvent(planUpdate(1L, json(singleActionPlan("newAction"))));
+            harness.prepareSnapshotPreBarrier(1L);
+            harness.snapshot(1L, 1L);
+
+            assertThat(bridge.getPythonActionExecutor()).isNotSameAs(oldExecutor);
+        }
+    }
+
+    @Test
+    void javaRunnerContextIsReboundToTheActivatedPlan() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                harness(configuredActionPlan("old-context"))) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            harness.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+
+            op.handleOperatorEvent(planUpdate(1L, json(configuredActionPlan("new-context"))));
+            checkpoint(harness, 1L);
+            harness.processElement(new StreamRecord<>(2L));
+            op.waitInFlightEventsFinished();
+
+            assertThat(outputs(harness)).containsExactly("old-context", "new-context");
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    /** Mirrors the task's barrier sequence: prepareSnapshotPreBarrier, then the snapshot. */
+    private static OperatorSubtaskState checkpoint(
+            KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness, long checkpointId)
+            throws Exception {
+        harness.prepareSnapshotPreBarrier(checkpointId);
+        return harness.snapshot(checkpointId, checkpointId);
+    }
+
+    private static PlanUpdateEvent planUpdate(long planVersion, String agentPlanJson) {
+        return new PlanUpdateEvent(planVersion, PlanIds.planIdOf(agentPlanJson), agentPlanJson);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ActionExecutionOperator<Long, Object> op(
+            KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness) {
+        return (ActionExecutionOperator<Long, Object>) harness.getOperator();
+    }
+
+    private static List<Object> outputs(
+            KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness) {
+        return harness.getRecordOutput().stream()
+                .map(StreamRecord::getValue)
+                .collect(Collectors.toList());
+    }
+
+    private static KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness()
+            throws Exception {
+        return harness(singleActionPlan("oldAction"));
+    }
+
+    private static KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness(
+            AgentPlan plan) throws Exception {
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                new ActionExecutionOperatorFactory<>(plan, true),
+                (KeySelector<Long, Long>) value -> value,
+                TypeInformation.of(Long.class));
+    }
+
+    private static KeyedOneInputStreamOperatorTestHarness<Long, Row, Object> pythonWireHarness()
+            throws Exception {
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                new ActionExecutionOperatorFactory<>(singleActionPlan("oldAction"), false),
+                (KeySelector<Row, Long>) value -> 0L,
+                TypeInformation.of(Long.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ActionExecutionOperator<Row, Object> rowOp(
+            KeyedOneInputStreamOperatorTestHarness<Long, Row, Object> harness) {
+        return (ActionExecutionOperator<Row, Object>) harness.getOperator();
+    }
+
+    private static PythonBridgeManager pythonBridge(ActionExecutionOperator<?, ?> operator)
+            throws Exception {
+        Field field = ActionExecutionOperator.class.getDeclaredField("pythonBridge");
+        field.setAccessible(true);
+        return (PythonBridgeManager) field.get(operator);
+    }
+
+    private static String json(AgentPlan plan) throws Exception {
+        return OBJECT_MAPPER.writeValueAsString(plan);
+    }
+
+    public static void oldAction(Event event, RunnerContext context) {
+        context.sendEvent(new OutputEvent("old:" + InputEvent.fromEvent(event).getInput()));
+    }
+
+    public static void newAction(Event event, RunnerContext context) {
+        context.sendEvent(new OutputEvent("new:" + InputEvent.fromEvent(event).getInput()));
+    }
+
+    public static void newerAction(Event event, RunnerContext context) {
+        context.sendEvent(new OutputEvent("newer:" + InputEvent.fromEvent(event).getInput()));
+    }
+
+    public static void configuredAction(Event event, RunnerContext context) {
+        context.sendEvent(new OutputEvent(context.getActionConfigValue("marker")));
+    }
+
+    private static AgentPlan singleActionPlan(String method) throws Exception {
+        Action action =
+                new Action(
+                        "action",
+                        new JavaFunction(
+                                DynamicPlanSwitchOperatorTest.class,
+                                method,
+                                new Class<?>[] {Event.class, RunnerContext.class}),
+                        Collections.singletonList(InputEvent.EVENT_TYPE));
+        Map<String, Action> actions = new HashMap<>();
+        actions.put(action.getName(), action);
+        Map<String, List<Action>> byEvent = new HashMap<>();
+        byEvent.put(InputEvent.EVENT_TYPE, Collections.singletonList(action));
+        AgentConfiguration config = new AgentConfiguration();
+        return new AgentPlan(actions, byEvent, new HashMap<>(), config);
+    }
+
+    private static AgentPlan configuredActionPlan(String marker) throws Exception {
+        Action action =
+                new Action(
+                        "configuredAction",
+                        new JavaFunction(
+                                DynamicPlanSwitchOperatorTest.class,
+                                "configuredAction",
+                                new Class<?>[] {Event.class, RunnerContext.class}),
+                        Collections.singletonList(InputEvent.EVENT_TYPE),
+                        new HashMap<>(Map.of("marker", marker)));
+        return new AgentPlan(
+                Map.of(action.getName(), action),
+                Map.of(InputEvent.EVENT_TYPE, List.of(action)),
+                new HashMap<>(),
+                new AgentConfiguration());
+    }
+
+    private static AgentPlan pythonPlan(String functionName) throws Exception {
+        Action action =
+                new Action(
+                        "pythonAction",
+                        new PythonFunction(
+                                "flink_agents.plan.tests.dynamic_plan_test_actions", functionName),
+                        Collections.singletonList(InputEvent.EVENT_TYPE));
+        AgentConfiguration config = new AgentConfiguration();
+        config.setInt("num-async-threads", 1);
+        return new AgentPlan(
+                Map.of(action.getName(), action),
+                Map.of(InputEvent.EVENT_TYPE, List.of(action)),
+                new HashMap<>(),
+                config);
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -28,6 +28,8 @@ import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.JavaFunction;
 import org.apache.flink.agents.plan.PythonFunction;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.actionstate.ActionState;
+import org.apache.flink.agents.runtime.actionstate.InMemoryActionStateStore;
 import org.apache.flink.agents.runtime.operator.coordinator.PlanIds;
 import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateEvent;
 import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
@@ -138,6 +140,120 @@ public class DynamicPlanSwitchOperatorTest {
             restored.processElement(new StreamRecord<>(4L));
             op.waitInFlightEventsFinished();
             assertThat(outputs(restored)).containsExactly("new:4");
+        }
+    }
+
+    @Test
+    void samePlanIdReusesActionStateAcrossPlanVersions() throws Exception {
+        AgentPlan bootstrapPlan = singleActionPlan("oldAction");
+        AgentPlan repeatedPlan = singleActionPlan("newAction");
+        String repeatedPlanJson = canonicalJson(repeatedPlan);
+        String repeatedPlanId = PlanIds.planIdOf(repeatedPlanJson);
+        InMemoryActionStateStore store = new InMemoryActionStateStore(false);
+        InputEvent inputEvent = new InputEvent(42L);
+        ActionState state = new ActionState(inputEvent);
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                harness(bootstrapPlan, store)) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            op.handleOperatorEvent(new PlanUpdateEvent(1L, repeatedPlanId, repeatedPlanJson));
+            checkpoint(harness, 1L);
+            Action firstAction = op.getCurrentPlanForTesting().getActions().get("newAction");
+            store.put("scope-key", 42L, firstAction, inputEvent, state);
+
+            op.handleOperatorEvent(new PlanUpdateEvent(2L, repeatedPlanId, repeatedPlanJson));
+            checkpoint(harness, 2L);
+            Action secondAction = op.getCurrentPlanForTesting().getActions().get("newAction");
+
+            assertThat(store.get("scope-key", 42L, secondAction, inputEvent)).isSameAs(state);
+        }
+    }
+
+    @Test
+    void reusedPlanVersionDoesNotReplayStateFromDifferentCandidate() throws Exception {
+        AgentPlan bootstrapPlan = singleActionPlan("oldAction");
+        InMemoryActionStateStore store = new InMemoryActionStateStore(false);
+        InputEvent inputEvent = new InputEvent(42L);
+        ActionState candidateAState = new ActionState(inputEvent);
+        OperatorSubtaskState bootstrapSnapshot;
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                harness(bootstrapPlan, store)) {
+            harness.open();
+            bootstrapSnapshot = checkpoint(harness, 1L);
+
+            AgentPlan candidateA = configuredActionPlan("candidate-a");
+            String candidateAJson = canonicalJson(candidateA);
+            op(harness)
+                    .handleOperatorEvent(
+                            new PlanUpdateEvent(
+                                    1L, PlanIds.planIdOf(candidateAJson), candidateAJson));
+            checkpoint(harness, 2L);
+            Action actionA =
+                    op(harness).getCurrentPlanForTesting().getActions().get("configuredAction");
+            store.put("scope-key", 42L, actionA, inputEvent, candidateAState);
+        }
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restored =
+                harness(bootstrapPlan, store)) {
+            restored.initializeState(bootstrapSnapshot);
+            restored.open();
+
+            AgentPlan candidateB = configuredActionPlan("candidate-b");
+            String candidateBJson = canonicalJson(candidateB);
+            op(restored)
+                    .handleOperatorEvent(
+                            new PlanUpdateEvent(
+                                    1L, PlanIds.planIdOf(candidateBJson), candidateBJson));
+            checkpoint(restored, 3L);
+            Action actionB =
+                    op(restored).getCurrentPlanForTesting().getActions().get("configuredAction");
+
+            assertThat(store.get("scope-key", 42L, actionB, inputEvent)).isNull();
+        }
+    }
+
+    @Test
+    void coordinatorPlanIdSurvivesEffectivePlanSnapshotAndRestore() throws Exception {
+        AgentPlan bootstrapPlan = singleActionPlan("oldAction");
+        String bootstrapPlanId =
+                PlanIds.planIdOf(PlanVersionManager.canonicalJsonOf(bootstrapPlan));
+        AgentPlan submittedPlan = singleActionPlan("newAction");
+        submittedPlan.getConfig().setStr("update-only-key", "discarded-by-config-pinning");
+        String submittedPlanJson = canonicalJson(submittedPlan);
+        String coordinatorPlanId = PlanIds.planIdOf(submittedPlanJson);
+        OperatorSubtaskState snapshot;
+
+        InMemoryActionStateStore firstStore = new InMemoryActionStateStore(false);
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
+                harness(bootstrapPlan, firstStore)) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+            assertThat(op.getCurrentPlanIdForTesting()).isEqualTo(bootstrapPlanId);
+            assertThat(firstStore.getActivePlanId()).isEqualTo(bootstrapPlanId);
+
+            op.handleOperatorEvent(new PlanUpdateEvent(1L, coordinatorPlanId, submittedPlanJson));
+            snapshot = checkpoint(harness, 1L);
+
+            assertThat(op.getCurrentPlanIdForTesting()).isEqualTo(coordinatorPlanId);
+            assertThat(firstStore.getActivePlanId()).isEqualTo(coordinatorPlanId);
+            assertThat(
+                            PlanIds.planIdOf(
+                                    PlanVersionManager.canonicalJsonOf(
+                                            op.getCurrentPlanForTesting())))
+                    .isNotEqualTo(coordinatorPlanId);
+        }
+
+        InMemoryActionStateStore restoredStore = new InMemoryActionStateStore(false);
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restored =
+                harness(bootstrapPlan, restoredStore)) {
+            restored.initializeState(snapshot);
+            restored.open();
+
+            assertThat(op(restored).getCurrentPlanIdForTesting()).isEqualTo(coordinatorPlanId);
+            assertThat(restoredStore.getActivePlanId()).isEqualTo(coordinatorPlanId);
         }
     }
 
@@ -331,8 +447,13 @@ public class DynamicPlanSwitchOperatorTest {
 
     private static KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness(
             AgentPlan plan) throws Exception {
+        return harness(plan, null);
+    }
+
+    private static KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness(
+            AgentPlan plan, InMemoryActionStateStore actionStateStore) throws Exception {
         return new KeyedOneInputStreamOperatorTestHarness<>(
-                new ActionExecutionOperatorFactory<>(plan, true),
+                new ActionExecutionOperatorFactory<>(plan, true, actionStateStore),
                 (KeySelector<Long, Long>) value -> value,
                 TypeInformation.of(Long.class));
     }
@@ -360,6 +481,10 @@ public class DynamicPlanSwitchOperatorTest {
 
     private static String json(AgentPlan plan) throws Exception {
         return OBJECT_MAPPER.writeValueAsString(plan);
+    }
+
+    private static String canonicalJson(AgentPlan plan) throws Exception {
+        return PlanIds.canonicalize(json(plan));
     }
 
     public static void oldAction(Event event, RunnerContext context) {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -83,7 +83,7 @@ public class DynamicPlanSwitchOperatorTest {
             checkpoint(harness, 1L);
             assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
             assertThat(op.hasPendingPlanForTesting()).isFalse();
-            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("action");
+            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("newAction");
 
             harness.processElement(new StreamRecord<>(3L));
             op.waitInFlightEventsFinished();
@@ -133,7 +133,7 @@ public class DynamicPlanSwitchOperatorTest {
             ActionExecutionOperator<Long, Object> op = op(restored);
 
             assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(1L);
-            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("action");
+            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("newAction");
 
             restored.processElement(new StreamRecord<>(4L));
             op.waitInFlightEventsFinished();
@@ -195,9 +195,7 @@ public class DynamicPlanSwitchOperatorTest {
 
             checkpoint(harness, 1L);
             assertThat(op.getCurrentPlanVersionForTesting()).isEqualTo(2L);
-            harness.processElement(new StreamRecord<>(10L));
-            op.waitInFlightEventsFinished();
-            assertThat(outputs(harness)).containsExactly("newer:10");
+            assertThat(op.getCurrentPlanForTesting().getActions()).containsOnlyKeys("newerAction");
         }
     }
 
@@ -383,7 +381,7 @@ public class DynamicPlanSwitchOperatorTest {
     private static AgentPlan singleActionPlan(String method) throws Exception {
         Action action =
                 new Action(
-                        "action",
+                        method,
                         new JavaFunction(
                                 DynamicPlanSwitchOperatorTest.class,
                                 method,

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -338,15 +338,23 @@ public class DynamicPlanSwitchOperatorTest {
             newPlan.getConfig().setStr("job-identifier", "attempted-override");
             newPlan.getConfig().setInt("num-async-threads", 1);
             newPlan.getConfig().setStr("update-only-key", "ignored");
+            newPlan.getConfig()
+                    .setStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, "/tmp/plan-v1.jar");
+            newPlan.getConfig()
+                    .setStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, "artifact-digest");
             op.handleOperatorEvent(planUpdate(1L, json(newPlan)));
             checkpoint(harness, 1L);
 
-            // Job-level configuration is pinned at submission; only the update's plan structure
-            // (actions, routing and resources) is applied.
+            // Job-level configuration is pinned at submission; artifact coordinates are the
+            // plan-scoped exception.
             AgentConfiguration effective = op.getCurrentPlanForTesting().getConfig();
             assertThat(effective.getStr("job-identifier", null)).isNull();
             assertThat(effective.getInt("num-async-threads", -1)).isEqualTo(-1);
             assertThat(effective.getStr("update-only-key", null)).isNull();
+            assertThat(effective.getStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, null))
+                    .isEqualTo("/tmp/plan-v1.jar");
+            assertThat(effective.getStr(PlanVersionManager.JAVA_ARTIFACT_SHA256_CONFIG, null))
+                    .isEqualTo("artifact-digest");
         }
     }
 

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/DynamicPlanSwitchOperatorTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.agents.runtime.actionstate.ActionState;
 import org.apache.flink.agents.runtime.actionstate.InMemoryActionStateStore;
 import org.apache.flink.agents.runtime.operator.coordinator.PlanIds;
 import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateEvent;
+import org.apache.flink.agents.runtime.python.utils.JavaResourceAdapter;
 import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -42,12 +43,17 @@ import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import javax.tools.JavaCompiler;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.JarEntry;
@@ -439,6 +445,87 @@ public class DynamicPlanSwitchOperatorTest {
     }
 
     @Test
+    void javaArtifactLoadsActionClassAbsentFromTheJobClasspath(@TempDir Path tempDir)
+            throws Exception {
+        String className = "user.dynamic.ExternalAction";
+        Path artifact = createExternalJavaActionJar(tempDir.resolve("v1"), className, 100L);
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+
+            op.handleOperatorEvent(
+                    planUpdate(1L, json(externalJavaArtifactPlan(artifact, className))));
+            checkpoint(harness, 1L);
+            harness.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+
+            assertThat(outputs(harness)).containsExactly(101L);
+        }
+    }
+
+    @Test
+    void restoredJavaArtifactPlanRecreatesItsClassLoader(@TempDir Path tempDir) throws Exception {
+        String className = "user.dynamic.ExternalAction";
+        Path artifact = createExternalJavaActionJar(tempDir.resolve("v2"), className, 200L);
+        OperatorSubtaskState snapshot;
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness = harness()) {
+            harness.open();
+            ActionExecutionOperator<Long, Object> op = op(harness);
+            op.handleOperatorEvent(
+                    planUpdate(1L, json(externalJavaArtifactPlan(artifact, className))));
+            snapshot = checkpoint(harness, 1L);
+        }
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> restored = harness()) {
+            restored.initializeState(snapshot);
+            restored.open();
+            ActionExecutionOperator<Long, Object> op = op(restored);
+            restored.processElement(new StreamRecord<>(1L));
+            op.waitInFlightEventsFinished();
+
+            assertThat(outputs(restored)).containsExactly(201L);
+        }
+    }
+
+    @Test
+    void pythonBridgeUsesTheActivePlanJavaArtifactClassLoaderAfterSwitchAndRestore(
+            @TempDir Path tempDir) throws Exception {
+        String className = "user.dynamic.ExternalAction";
+        Path artifact = createExternalJavaActionJar(tempDir.resolve("bridge"), className, 300L);
+        OperatorSubtaskState snapshot;
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Row, Object> harness =
+                pythonWireHarness()) {
+            harness.open();
+            ActionExecutionOperator<Row, Object> op = rowOp(harness);
+            op.handleOperatorEvent(
+                    planUpdate(1L, json(externalJavaArtifactPlan(artifact, className))));
+            harness.prepareSnapshotPreBarrier(1L);
+            snapshot = harness.snapshot(1L, 1L);
+
+            Object result =
+                    javaResourceAdapter(pythonBridge(op))
+                            .invokeJavaAction(className, "probe", List.of(), List.of());
+
+            assertThat(result).isEqualTo(300L);
+        }
+
+        try (KeyedOneInputStreamOperatorTestHarness<Long, Row, Object> restored =
+                pythonWireHarness()) {
+            restored.initializeState(snapshot);
+            restored.open();
+
+            Object result =
+                    javaResourceAdapter(pythonBridge(rowOp(restored)))
+                            .invokeJavaAction(className, "probe", List.of(), List.of());
+
+            assertThat(result).isEqualTo(300L);
+        }
+    }
+
+    @Test
     void existingPythonActionCanSwitchWithoutAnArtifact() throws Exception {
         try (KeyedOneInputStreamOperatorTestHarness<Long, Long, Object> harness =
                 harness(pythonPlan("old_action"))) {
@@ -567,6 +654,16 @@ public class DynamicPlanSwitchOperatorTest {
         return (PythonBridgeManager) field.get(operator);
     }
 
+    private static JavaResourceAdapter javaResourceAdapter(PythonBridgeManager bridge)
+            throws Exception {
+        Field activeRuntimeField = PythonBridgeManager.class.getDeclaredField("activeRuntime");
+        activeRuntimeField.setAccessible(true);
+        Object activeRuntime = activeRuntimeField.get(bridge);
+        Field adapterField = activeRuntime.getClass().getDeclaredField("javaResourceAdapter");
+        adapterField.setAccessible(true);
+        return (JavaResourceAdapter) adapterField.get(activeRuntime);
+    }
+
     private static String json(AgentPlan plan) throws Exception {
         return OBJECT_MAPPER.writeValueAsString(plan);
     }
@@ -647,6 +744,26 @@ public class DynamicPlanSwitchOperatorTest {
         return plan;
     }
 
+    private static AgentPlan externalJavaArtifactPlan(Path artifactPath, String className)
+            throws Exception {
+        Action action =
+                new Action(
+                        "externalJavaAction",
+                        new JavaFunction(
+                                className,
+                                "execute",
+                                new Class<?>[] {Event.class, RunnerContext.class}),
+                        Collections.singletonList(InputEvent.EVENT_TYPE));
+        AgentPlan plan =
+                new AgentPlan(
+                        Map.of(action.getName(), action),
+                        Map.of(InputEvent.EVENT_TYPE, List.of(action)),
+                        new HashMap<>(),
+                        new AgentConfiguration());
+        configureJavaArtifact(plan, artifactPath);
+        return plan;
+    }
+
     private static void configureJavaArtifact(AgentPlan plan, Path artifactPath) throws Exception {
         plan.getConfig()
                 .setStr(PlanVersionManager.JAVA_ARTIFACT_PATH_CONFIG, artifactPath.toString());
@@ -656,6 +773,74 @@ public class DynamicPlanSwitchOperatorTest {
                         PlanIds.sha256HexOfFile(artifactPath));
     }
 
+    private static Path createExternalJavaActionJar(Path directory, String className, long addend)
+            throws Exception {
+        String packageName = className.substring(0, className.lastIndexOf('.'));
+        String simpleName = className.substring(className.lastIndexOf('.') + 1);
+        String source =
+                "package "
+                        + packageName
+                        + ";\n"
+                        + "import org.apache.flink.agents.api.Event;\n"
+                        + "import org.apache.flink.agents.api.InputEvent;\n"
+                        + "import org.apache.flink.agents.api.OutputEvent;\n"
+                        + "import org.apache.flink.agents.api.context.RunnerContext;\n"
+                        + "public class "
+                        + simpleName
+                        + " {\n"
+                        + "  public static void execute(Event event, RunnerContext context) {\n"
+                        + "    Long input = (Long) InputEvent.fromEvent(event).getInput();\n"
+                        + "    context.sendEvent(new OutputEvent(input + "
+                        + addend
+                        + "L));\n"
+                        + "  }\n"
+                        + "  public static long probe() { return "
+                        + addend
+                        + "L; }\n"
+                        + "}\n";
+
+        Path sourceRoot = directory.resolve("src");
+        Path classesRoot = directory.resolve("classes");
+        Path sourceFile =
+                sourceRoot.resolve(packageName.replace('.', '/')).resolve(simpleName + ".java");
+        Files.createDirectories(sourceFile.getParent());
+        Files.createDirectories(classesRoot);
+        Files.writeString(sourceFile, source, StandardCharsets.UTF_8);
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        assertThat(compiler).as("JDK compiler must be available").isNotNull();
+        try (StandardJavaFileManager fileManager =
+                compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)) {
+            Boolean success =
+                    compiler.getTask(
+                                    null,
+                                    fileManager,
+                                    null,
+                                    List.of(
+                                            "-classpath",
+                                            testCompilerClasspath(),
+                                            "-d",
+                                            classesRoot.toString()),
+                                    null,
+                                    fileManager.getJavaFileObjects(sourceFile))
+                            .call();
+            assertThat(success).isTrue();
+        }
+
+        Path artifact = directory.resolve("external-action-" + addend + ".jar");
+        try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(artifact))) {
+            Path classFile =
+                    classesRoot
+                            .resolve(packageName.replace('.', '/'))
+                            .resolve(simpleName + ".class");
+            jar.putNextEntry(
+                    new JarEntry(packageName.replace('.', '/') + "/" + simpleName + ".class"));
+            Files.copy(classFile, jar);
+            jar.closeEntry();
+        }
+        return artifact;
+    }
+
     private static Path writeJavaArtifact(Path artifact, String marker) throws Exception {
         try (JarOutputStream jar = new JarOutputStream(Files.newOutputStream(artifact))) {
             jar.putNextEntry(new JarEntry("marker.txt"));
@@ -663,5 +848,25 @@ public class DynamicPlanSwitchOperatorTest {
             jar.closeEntry();
         }
         return artifact;
+    }
+
+    private static String testCompilerClasspath() throws Exception {
+        LinkedHashSet<String> entries = new LinkedHashSet<>();
+        addCodeSource(entries, Event.class);
+        addCodeSource(entries, InputEvent.class);
+        addCodeSource(entries, OutputEvent.class);
+        addCodeSource(entries, RunnerContext.class);
+        for (String entry :
+                System.getProperty("java.class.path").split(java.io.File.pathSeparator)) {
+            if (!entry.isEmpty()) {
+                entries.add(entry);
+            }
+        }
+        return String.join(java.io.File.pathSeparator, entries);
+    }
+
+    private static void addCodeSource(LinkedHashSet<String> entries, Class<?> clazz)
+            throws Exception {
+        entries.add(clazz.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
@@ -20,14 +20,20 @@ package org.apache.flink.agents.runtime.operator;
 import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.plan.AgentPlan;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.junit.jupiter.api.Test;
+import pemja.core.PythonInterpreter;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /** Contract tests for {@link PythonBridgeManager}. */
 class PythonBridgeManagerTest {
@@ -58,5 +64,19 @@ class PythonBridgeManagerTest {
             assertThat(bridge.getPythonActionExecutor()).isNull();
             assertThat(bridge.getPythonRunnerContext()).isNull();
         }
+    }
+
+    @Test
+    void runtimeCloseStillClosesInterpreterWhenExecutorCloseFails() throws Exception {
+        PythonActionExecutor executor = mock(PythonActionExecutor.class);
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        doThrow(new Exception("executor close failed")).when(executor).close();
+
+        PythonBridgeManager.PlanPythonRuntime runtime =
+                new PythonBridgeManager.PlanPythonRuntime(
+                        executor, null, null, null, null, interpreter);
+
+        assertThatThrownBy(runtime::close).hasMessageContaining("executor close failed");
+        verify(interpreter).close();
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
@@ -18,16 +18,25 @@
 package org.apache.flink.agents.runtime.operator;
 
 import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.plan.AgentConfiguration;
 import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.plan.PythonFunction;
 import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanIds;
 import org.apache.flink.agents.runtime.python.utils.PythonActionExecutor;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import pemja.core.PythonInterpreter;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,6 +46,80 @@ import static org.mockito.Mockito.verify;
 
 /** Contract tests for {@link PythonBridgeManager}. */
 class PythonBridgeManagerTest {
+
+    @Test
+    void pythonArtifactMetadataIsValidatedWithoutStartingCPython(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = pythonArtifact(tempDir.resolve("agent.zip"));
+
+        try (PythonBridgeManager bridge = new PythonBridgeManager()) {
+            bridge.validatePythonPlanMetadata(pythonPlan(artifact));
+
+            assertThat(bridge.isInitialized()).isFalse();
+        }
+    }
+
+    @Test
+    void invalidPythonArtifactDigestIsRejectedBeforeStartingCPython(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = pythonArtifact(tempDir.resolve("agent.zip"));
+        AgentPlan plan = pythonPlan(artifact);
+        plan.getConfig().setStr(PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG, "0".repeat(64));
+
+        try (PythonBridgeManager bridge = new PythonBridgeManager()) {
+            assertThatThrownBy(() -> bridge.validatePythonPlanMetadata(plan))
+                    .hasMessageContaining("failed sha256 verification");
+            assertThat(bridge.isInitialized()).isFalse();
+        }
+    }
+
+    @Test
+    void pythonArtifactPathAndDigestMustBeConfiguredTogether(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = pythonArtifact(tempDir.resolve("agent.zip"));
+        AgentPlan pathOnly = pythonPlan(artifact);
+        pathOnly.getConfig()
+                .getConfData()
+                .remove(PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG);
+        AgentPlan digestOnly = pythonPlan(artifact);
+        digestOnly
+                .getConfig()
+                .getConfData()
+                .remove(PythonBridgeManager.PYTHON_ARTIFACT_PATH_CONFIG);
+
+        try (PythonBridgeManager bridge = new PythonBridgeManager()) {
+            assertThatThrownBy(() -> bridge.validatePythonPlanMetadata(pathOnly))
+                    .hasMessageContaining("must be configured together");
+            assertThatThrownBy(() -> bridge.validatePythonPlanMetadata(digestOnly))
+                    .hasMessageContaining("must be configured together");
+        }
+    }
+
+    @Test
+    void pythonArtifactMustBeARegularFile(@TempDir Path tempDir) throws Exception {
+        try (PythonBridgeManager bridge = new PythonBridgeManager()) {
+            assertThatThrownBy(() -> bridge.validatePythonPlanMetadata(pythonPlan(tempDir)))
+                    .hasMessageContaining("regular file");
+        }
+    }
+
+    @Test
+    void overwritingOnePythonArtifactPathWithAnotherDigestIsRejected(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = pythonArtifact(tempDir.resolve("agent.zip"));
+        AgentPlan current = pythonPlan(artifact);
+        AgentPlan update = pythonPlan(artifact);
+        current.getConfig()
+                .setStr(PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG, "1".repeat(64));
+        update.getConfig()
+                .setStr(PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG, "2".repeat(64));
+
+        try (PythonBridgeManager bridge = new PythonBridgeManager()) {
+            assertThatThrownBy(() -> bridge.validatePythonPlanTransition(current, update))
+                    .hasMessageContaining("python-artifact.path")
+                    .hasMessageContaining("immutable");
+        }
+    }
 
     @Test
     void openIsNoOpWhenPlanHasNeitherPythonActionsNorResources() throws Exception {
@@ -78,5 +161,47 @@ class PythonBridgeManagerTest {
 
         assertThatThrownBy(runtime::close).hasMessageContaining("executor close failed");
         verify(interpreter).close();
+    }
+
+    @Test
+    void nonZipPythonArtifactIsRejectedBeforeStartingCPython(@TempDir Path tempDir)
+            throws Exception {
+        Path artifact = tempDir.resolve("agent.zip");
+        Files.writeString(artifact, "not a zip archive");
+
+        try (PythonBridgeManager bridge = new PythonBridgeManager()) {
+            assertThatThrownBy(() -> bridge.validatePythonPlanMetadata(pythonPlan(artifact)))
+                    .hasMessageContaining("valid zip or wheel");
+            assertThat(bridge.isInitialized()).isFalse();
+        }
+    }
+
+    private static AgentPlan pythonPlan(Path artifact) throws Exception {
+        Action action =
+                new Action(
+                        "pythonAction",
+                        new PythonFunction("app.agent", "handle"),
+                        List.of(InputEvent.EVENT_TYPE));
+        Map<String, Action> actions = Map.of(action.getName(), action);
+        Map<String, List<Action>> byEvent = Map.of(InputEvent.EVENT_TYPE, List.of(action));
+        AgentConfiguration config = new AgentConfiguration();
+        config.setStr(PythonBridgeManager.PYTHON_ARTIFACT_PATH_CONFIG, artifact.toString());
+        if (Files.isRegularFile(artifact)) {
+            config.setStr(
+                    PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG,
+                    PlanIds.sha256HexOfFile(artifact));
+        } else {
+            config.setStr(PythonBridgeManager.PYTHON_ARTIFACT_SHA256_CONFIG, "0".repeat(64));
+        }
+        return new AgentPlan(actions, byEvent, new HashMap<>(), config);
+    }
+
+    private static Path pythonArtifact(Path artifact) throws Exception {
+        try (ZipOutputStream zip = new ZipOutputStream(Files.newOutputStream(artifact))) {
+            zip.putNextEntry(new ZipEntry("app/agent.py"));
+            zip.write("def handle(value):\n    return value\n".getBytes());
+            zip.closeEntry();
+        }
+        return artifact;
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/PythonBridgeManagerTest.java
@@ -140,27 +140,15 @@ class PythonBridgeManagerTest {
                     /* metricGroup */ null,
                     /* mailboxThreadChecker */ () -> {},
                     /* jobIdentifier */ "job-1",
-                    /* userCodeClassLoader */ Thread.currentThread().getContextClassLoader());
+                    /* userCodeClassLoader */ Thread.currentThread().getContextClassLoader(),
+                    /* operatorIdentifier */ "0123456789abcdef",
+                    /* planVersion */ 0L);
 
             // No-op contract: nothing initialized, no Pemja interpreter created.
             assertThat(bridge.isInitialized()).isFalse();
             assertThat(bridge.getPythonActionExecutor()).isNull();
             assertThat(bridge.getPythonRunnerContext()).isNull();
         }
-    }
-
-    @Test
-    void runtimeCloseStillClosesInterpreterWhenExecutorCloseFails() throws Exception {
-        PythonActionExecutor executor = mock(PythonActionExecutor.class);
-        PythonInterpreter interpreter = mock(PythonInterpreter.class);
-        doThrow(new Exception("executor close failed")).when(executor).close();
-
-        PythonBridgeManager.PlanPythonRuntime runtime =
-                new PythonBridgeManager.PlanPythonRuntime(
-                        executor, null, null, null, null, interpreter);
-
-        assertThatThrownBy(runtime::close).hasMessageContaining("executor close failed");
-        verify(interpreter).close();
     }
 
     @Test
@@ -174,6 +162,33 @@ class PythonBridgeManagerTest {
                     .hasMessageContaining("valid zip or wheel");
             assertThat(bridge.isInitialized()).isFalse();
         }
+    }
+
+    @Test
+    void runtimeCloseRetiresArtifactWhenExecutorCloseFails() throws Exception {
+        PythonActionExecutor executor = mock(PythonActionExecutor.class);
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        doThrow(new Exception("executor close failed")).when(executor).close();
+
+        PythonBridgeManager.PlanPythonRuntime runtime =
+                new PythonBridgeManager.PlanPythonRuntime(
+                        executor, null, null, null, null, interpreter, "__fa_job_operator_v1");
+
+        assertThatThrownBy(runtime::close).hasMessageContaining("executor close failed");
+        verify(interpreter)
+                .invokeMethod(
+                        "__fa_plan_function",
+                        "release_python_module_namespace",
+                        "__fa_job_operator_v1");
+        verify(interpreter).close();
+    }
+
+    @Test
+    void moduleNamespaceIncludesJobOperatorAndPlanVersion() {
+        JobID jobId = new JobID(0x1234L, 0x5678L);
+
+        assertThat(PythonBridgeManager.pythonModuleNamespace(jobId, "abcdef", 42L))
+                .isEqualTo("__fa_00000000000012340000000000005678_abcdef_v42");
     }
 
     private static AgentPlan pythonPlan(Path artifact) throws Exception {

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateCoordinatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateCoordinatorTest.java
@@ -60,8 +60,11 @@ public class PlanUpdateCoordinatorTest {
         PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
         FakeGateway gateway = ready(coordinator, 0);
 
-        PlanUpdateResponse response = submit(coordinator, json(plan("actionA")));
+        String submittedJson = json(plan("actionA"));
+        String canonicalJson = PlanIds.canonicalize(submittedJson);
+        PlanUpdateResponse response = submit(coordinator, submittedJson);
         assertThat(response.planVersion).isEqualTo(1L);
+        assertThat(response.planId).isEqualTo(PlanIds.planIdOf(canonicalJson));
         // The candidate is volatile and nothing goes out before every subtask crossed K.
         assertThat(gateway.sentEvents).isEmpty();
 
@@ -76,7 +79,10 @@ public class PlanUpdateCoordinatorTest {
         // K completed globally: announce to every subtask.
         coordinator.notifyCheckpointComplete(10L);
         assertThat(gateway.sentEvents).hasSize(1);
-        assertThat(((PlanUpdateEvent) gateway.sentEvents.get(0)).planVersion).isEqualTo(1L);
+        PlanUpdateEvent event = (PlanUpdateEvent) gateway.sentEvents.get(0);
+        assertThat(event.planVersion).isEqualTo(1L);
+        assertThat(event.planId).isEqualTo(response.planId);
+        assertThat(event.canonicalPlanJson).isEqualTo(canonicalJson);
     }
 
     @Test

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateCoordinatorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/operator/coordinator/PlanUpdateCoordinatorTest.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.operator.coordinator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.agents.api.Event;
+import org.apache.flink.agents.api.InputEvent;
+import org.apache.flink.agents.api.context.RunnerContext;
+import org.apache.flink.agents.plan.AgentConfiguration;
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.plan.JavaFunction;
+import org.apache.flink.agents.plan.actions.Action;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateCoordinator.CoordinatorState;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateEvent;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateRequest;
+import org.apache.flink.agents.runtime.operator.coordinator.PlanUpdateMessages.PlanUpdateResponse;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests the two-phase switch state machine of {@link PlanUpdateCoordinator}. */
+public class PlanUpdateCoordinatorTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void candidateIsAnnouncedOnlyAfterItsCheckpointCompletes() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        FakeGateway gateway = ready(coordinator, 0);
+
+        PlanUpdateResponse response = submit(coordinator, json(plan("actionA")));
+        assertThat(response.planVersion).isEqualTo(1L);
+        // The candidate is volatile and nothing goes out before every subtask crossed K.
+        assertThat(gateway.sentEvents).isEmpty();
+
+        CompletableFuture<byte[]> snapshot = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(10L, snapshot);
+        CoordinatorState persisted = state(snapshot);
+        assertThat(persisted.active).isNull();
+        assertThat(OBJECT_MAPPER.readTree(snapshot.get()).has("candidate")).isFalse();
+        assertThat(OBJECT_MAPPER.readTree(snapshot.get()).has("staged")).isFalse();
+        assertThat(gateway.sentEvents).isEmpty();
+
+        // K completed globally: announce to every subtask.
+        coordinator.notifyCheckpointComplete(10L);
+        assertThat(gateway.sentEvents).hasSize(1);
+        assertThat(((PlanUpdateEvent) gateway.sentEvents.get(0)).planVersion).isEqualTo(1L);
+    }
+
+    @Test
+    void completedCheckpointBeforeSubmissionDoesNotQualifyLaterCandidate() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        FakeGateway gateway = ready(coordinator, 0);
+
+        completeCheckpoint(coordinator, 9L);
+        submit(coordinator, json(plan("actionA")));
+
+        assertThat(gateway.sentEvents).isEmpty();
+        completeCheckpoint(coordinator, 10L);
+        assertThat(gateway.sentEvents).hasSize(1);
+    }
+
+    @Test
+    void activationIsRecordedByTheCheckpointAfterTheAnnounce() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+
+        // The checkpoint after the announce records active = candidate: restoring it implies every
+        // subtask switched at its barrier.
+        CompletableFuture<byte[]> snapshot = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(11L, snapshot);
+        CoordinatorState persisted = state(snapshot);
+        assertThat(persisted.active.planVersion).isEqualTo(1L);
+        assertThat(coordinator.getActiveForTesting()).isNull();
+        assertThat(coordinator.getCandidateForTesting().planVersion).isEqualTo(1L);
+        coordinator.notifyCheckpointComplete(11L);
+        assertThat(coordinator.getActiveForTesting().planVersion).isEqualTo(1L);
+        assertThat(coordinator.getCandidateForTesting()).isNull();
+
+        // The next update is sequenced on top of the activated version.
+        assertThat(submit(coordinator, json(plan("actionB"))).planVersion).isEqualTo(2L);
+    }
+
+    @Test
+    void updatesAreRejectedWhileCandidatePendingOrCheckpointInFlight() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        ready(coordinator, 0);
+        String planJson = json(plan("actionA"));
+        submit(coordinator, planJson);
+
+        // One in-flight update at a time.
+        assertThatThrownBy(() -> submit(coordinator, planJson))
+                .rootCause()
+                .hasMessageContaining("candidate and not yet effective");
+
+        // And while a checkpoint is in flight the gate stays shut as well.
+        completeCheckpoint(coordinator, 10L);
+        completeCheckpoint(coordinator, 11L); // activates v1
+        coordinator.checkpointCoordinator(12L, new CompletableFuture<>());
+        assertThatThrownBy(() -> submit(coordinator, planJson))
+                .rootCause()
+                .hasMessageContaining("checkpoint is in progress");
+        coordinator.notifyCheckpointComplete(12L);
+        assertThat(submit(coordinator, planJson).planVersion).isEqualTo(2L);
+    }
+
+    @Test
+    void nextCheckpointSnapshotWaitsForAnnounceDeliveryConfirmations() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        FakeGateway gateway = ready(coordinator, 0);
+        gateway.autoAck = false;
+
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L); // announce sent, delivery unconfirmed
+
+        // The barrier of the switch checkpoint must not exist before every subtask has the
+        // instruction: the coordinator snapshot (which gates barrier injection) stays incomplete
+        // until the delivery is confirmed.
+        CompletableFuture<byte[]> snapshot = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(11L, snapshot);
+        assertThat(snapshot).isNotDone();
+
+        gateway.ackAll();
+        assertThat(snapshot).isDone();
+        assertThat(state(snapshot).active.planVersion).isEqualTo(1L);
+    }
+
+    @Test
+    void failedAnnounceDeliveryFailsTheJob() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        FakeGateway gateway = ready(coordinator, 0);
+        gateway.autoAck = false;
+
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+        CompletableFuture<byte[]> activation = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(11L, activation);
+
+        gateway.failAll(new RuntimeException("delivery failed"));
+
+        assertThat(activation).isCompletedExceptionally();
+        assertThat(context.jobFailures).hasSize(1);
+        assertThat(context.jobFailures.get(0)).hasMessageContaining("planVersion 1");
+    }
+
+    @Test
+    void abortedCandidateCheckpointIsRetriedByTheNextCheckpoint() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        FakeGateway gateway = ready(coordinator, 0);
+
+        submit(coordinator, json(plan("actionA")));
+        coordinator.checkpointCoordinator(10L, new CompletableFuture<>());
+        coordinator.notifyCheckpointAborted(10L);
+        assertThat(gateway.sentEvents).isEmpty();
+
+        CompletableFuture<byte[]> retry = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(11L, retry);
+        assertThat(gateway.sentEvents).isEmpty();
+        coordinator.notifyCheckpointComplete(11L);
+        assertThat(gateway.sentEvents).hasSize(1);
+    }
+
+    @Test
+    void completionOfAnUnknownCheckpointDoesNotAnnounceTheCandidate() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        FakeGateway gateway = ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+
+        coordinator.notifyCheckpointComplete(10L);
+
+        assertThat(gateway.sentEvents).isEmpty();
+    }
+
+    @Test
+    void globalResetDropsAnnouncedCandidateBecauseItIsNotCheckpointed() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        FakeGateway gateway = ready(coordinator, 0);
+
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L); // announce v1
+        completeCheckpoint(coordinator, 11L); // activate v1
+
+        submit(coordinator, json(plan("actionB")));
+        CompletableFuture<byte[]> checkpointK = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(12L, checkpointK);
+        assertThat(state(checkpointK).active.planVersion).isEqualTo(1L);
+        coordinator.notifyCheckpointComplete(12L); // announce volatile v2
+        assertThat(gateway.sentEvents).hasSize(2);
+
+        PlanUpdateCoordinator restored = new PlanUpdateCoordinator(new FakeContext());
+        restored.resetToCheckpoint(12L, checkpointK.get());
+        FakeGateway restoredGateway = ready(restored, 0);
+
+        assertThat(restoredGateway.sentEvents).isEmpty();
+        assertThat(restored.getCandidateForTesting()).isNull();
+        assertThat(submit(restored, json(plan("actionB"))).planVersion).isEqualTo(2L);
+    }
+
+    @Test
+    void delayedDeliveryFailureFromBeforeResetDoesNotFailANewCandidate() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        FakeGateway oldGateway = ready(coordinator, 0);
+        oldGateway.autoAck = false;
+
+        submit(coordinator, json(plan("actionA")));
+        CompletableFuture<byte[]> checkpointK = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(10L, checkpointK);
+        coordinator.notifyCheckpointComplete(10L);
+        CompletableFuture<byte[]> abandonedActivation = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(11L, abandonedActivation);
+
+        coordinator.resetToCheckpoint(10L, checkpointK.get());
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionB")));
+
+        oldGateway.failAll(new RuntimeException("late delivery failure"));
+
+        assertThat(abandonedActivation).isCompletedExceptionally();
+        assertThat(context.jobFailures).isEmpty();
+        assertThat(coordinator.getCandidateForTesting().planVersion).isEqualTo(1L);
+    }
+
+    @Test
+    void synchronousAnnounceFailureFailsTheJob() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        FakeGateway gateway = ready(coordinator, 0);
+        gateway.sendFailure = new RuntimeException("send failed");
+
+        submit(coordinator, json(plan("actionA")));
+        CompletableFuture<byte[]> checkpointK = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(10L, checkpointK);
+        coordinator.notifyCheckpointComplete(10L);
+
+        assertThat(context.jobFailures).hasSize(1);
+        assertThat(context.jobFailures.get(0)).hasMessageContaining("planVersion 1");
+    }
+
+    @Test
+    void attemptFailureWhileCandidateExistsFailsTheJob() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+
+        coordinator.executionAttemptFailed(0, 0, new RuntimeException("prepare failed"));
+
+        assertThat(context.jobFailures).hasSize(1);
+        assertThat(context.jobFailures.get(0)).hasMessageContaining("planVersion 1");
+    }
+
+    @Test
+    void replacementAttemptAfterAnnounceFailsTheJob() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+
+        coordinator.executionAttemptReady(0, 1, new FakeGateway(0));
+
+        assertThat(context.jobFailures).hasSize(1);
+        assertThat(context.jobFailures.get(0)).hasMessageContaining("attempt 1");
+    }
+
+    @Test
+    void attemptFailureDuringActivationCheckpointFailsTheJob() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+
+        CompletableFuture<byte[]> activation = new CompletableFuture<>();
+        coordinator.checkpointCoordinator(11L, activation);
+        assertThat(activation).isDone();
+        coordinator.executionAttemptFailed(0, 0, new RuntimeException("activation failed"));
+
+        assertThat(context.jobFailures).hasSize(1);
+        assertThat(context.jobFailures.get(0)).hasMessageContaining("planVersion 1");
+    }
+
+    @Test
+    void abortedActivationCheckpointFailsTheJob() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+
+        coordinator.checkpointCoordinator(11L, new CompletableFuture<>());
+        coordinator.notifyCheckpointAborted(11L);
+
+        assertThat(context.jobFailures).hasSize(1);
+        assertThat(context.jobFailures.get(0)).hasMessageContaining("checkpoint 11");
+    }
+
+    @Test
+    void attemptFailureAfterActivationCheckpointCompletesUsesNormalFailover() throws Exception {
+        FakeContext context = new FakeContext();
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(context);
+        ready(coordinator, 0);
+        submit(coordinator, json(plan("actionA")));
+        completeCheckpoint(coordinator, 10L);
+        completeCheckpoint(coordinator, 11L);
+
+        coordinator.executionAttemptFailed(0, 0, new RuntimeException("unrelated failure"));
+
+        assertThat(context.jobFailures).isEmpty();
+    }
+
+    @Test
+    void restoreWithEmptyStateClearsTheGates() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        coordinator.checkpointCoordinator(1L, new CompletableFuture<>());
+        coordinator.resetToCheckpoint(1L, new byte[0]);
+        ready(coordinator, 0);
+        assertThat(submit(coordinator, json(plan("actionA"))).planVersion).isEqualTo(1L);
+    }
+
+    @Test
+    void restoreIgnoresTheLegacyStagedField() throws Exception {
+        PlanUpdateCoordinator coordinator = new PlanUpdateCoordinator(new FakeContext());
+        Map<String, Object> legacyState = new HashMap<>();
+        legacyState.put("active", new PlanUpdateCoordinator.PlanRecord(4L, "active", "{}"));
+        legacyState.put("staged", new PlanUpdateCoordinator.PlanRecord(5L, "staged", "{}"));
+
+        coordinator.resetToCheckpoint(4L, OBJECT_MAPPER.writeValueAsBytes(legacyState));
+        ready(coordinator, 0);
+
+        assertThat(coordinator.getActiveForTesting().planVersion).isEqualTo(4L);
+        assertThat(coordinator.getCandidateForTesting()).isNull();
+        assertThat(submit(coordinator, json(plan("actionA"))).planVersion).isEqualTo(5L);
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    private static PlanUpdateResponse submit(PlanUpdateCoordinator coordinator, String planJson)
+            throws Exception {
+        return (PlanUpdateResponse)
+                coordinator.handleCoordinationRequest(new PlanUpdateRequest(planJson)).get();
+    }
+
+    private static void completeCheckpoint(PlanUpdateCoordinator coordinator, long checkpointId) {
+        coordinator.checkpointCoordinator(checkpointId, new CompletableFuture<>());
+        coordinator.notifyCheckpointComplete(checkpointId);
+    }
+
+    private static CoordinatorState state(CompletableFuture<byte[]> snapshot) throws Exception {
+        return OBJECT_MAPPER.readValue(snapshot.get(), CoordinatorState.class);
+    }
+
+    private static FakeGateway ready(PlanUpdateCoordinator coordinator, int subtask) {
+        FakeGateway gateway = new FakeGateway(subtask);
+        coordinator.executionAttemptReady(subtask, 0, gateway);
+        return gateway;
+    }
+
+    public static void actionA(Event event, RunnerContext context) {}
+
+    public static void actionB(Event event, RunnerContext context) {}
+
+    private static AgentPlan plan(String method) throws Exception {
+        Action action =
+                new Action(
+                        method,
+                        new JavaFunction(
+                                PlanUpdateCoordinatorTest.class,
+                                method,
+                                new Class<?>[] {Event.class, RunnerContext.class}),
+                        Collections.singletonList(InputEvent.EVENT_TYPE));
+        Map<String, Action> actions = new HashMap<>();
+        actions.put(action.getName(), action);
+        Map<String, List<Action>> byEvent = new HashMap<>();
+        byEvent.put(InputEvent.EVENT_TYPE, Collections.singletonList(action));
+        return new AgentPlan(actions, byEvent, new HashMap<>(), new AgentConfiguration());
+    }
+
+    private static String json(AgentPlan plan) throws Exception {
+        return OBJECT_MAPPER.writeValueAsString(plan);
+    }
+
+    /** Records sent events; delivery confirmation is immediate unless {@code autoAck} is off. */
+    private static final class FakeGateway implements OperatorCoordinator.SubtaskGateway {
+        final List<OperatorEvent> sentEvents = new ArrayList<>();
+        final List<CompletableFuture<Acknowledge>> unacked = new ArrayList<>();
+        final int subtask;
+        boolean autoAck = true;
+        RuntimeException sendFailure;
+
+        FakeGateway(int subtask) {
+            this.subtask = subtask;
+        }
+
+        @Override
+        public CompletableFuture<Acknowledge> sendEvent(OperatorEvent event) {
+            if (sendFailure != null) {
+                throw sendFailure;
+            }
+            sentEvents.add(event);
+            CompletableFuture<Acknowledge> ack = new CompletableFuture<>();
+            if (autoAck) {
+                ack.complete(Acknowledge.get());
+            } else {
+                unacked.add(ack);
+            }
+            return ack;
+        }
+
+        void ackAll() {
+            unacked.forEach(f -> f.complete(Acknowledge.get()));
+            unacked.clear();
+        }
+
+        void failAll(Throwable failure) {
+            unacked.forEach(f -> f.completeExceptionally(failure));
+            unacked.clear();
+        }
+
+        @Override
+        public ExecutionAttemptID getExecution() {
+            return ExecutionAttemptID.randomId();
+        }
+
+        @Override
+        public int getSubtask() {
+            return subtask;
+        }
+    }
+
+    /** Minimal context that also records requests to escalate an update failure globally. */
+    private static final class FakeContext implements OperatorCoordinator.Context {
+        final List<Throwable> jobFailures = new ArrayList<>();
+
+        @Override
+        public JobID getJobID() {
+            return new JobID();
+        }
+
+        @Override
+        public OperatorID getOperatorId() {
+            return new OperatorID();
+        }
+
+        @Override
+        public OperatorCoordinatorMetricGroup metricGroup() {
+            return null;
+        }
+
+        @Override
+        public void failJob(Throwable cause) {
+            jobFailures.add(cause);
+        }
+
+        @Override
+        public int currentParallelism() {
+            return 1;
+        }
+
+        @Override
+        public ClassLoader getUserCodeClassloader() {
+            return getClass().getClassLoader();
+        }
+
+        @Override
+        public CoordinatorStore getCoordinatorStore() {
+            return null;
+        }
+
+        @Override
+        public boolean isConcurrentExecutionAttemptsSupported() {
+            return false;
+        }
+
+        @Override
+        public CheckpointCoordinator getCheckpointCoordinator() {
+            return null;
+        }
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
@@ -17,12 +17,16 @@
  */
 package org.apache.flink.agents.runtime.python.utils;
 
+import org.apache.flink.agents.api.InputEvent;
 import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.plan.PythonFunction;
+import org.apache.flink.agents.plan.actions.Action;
 import org.apache.flink.agents.runtime.python.context.PythonRunnerContextImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import pemja.core.PythonInterpreter;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,13 +67,44 @@ class PythonActionExecutorTest {
                 .doesNotContain("sys.modules[");
     }
 
+    @Test
+    void openResolvesDeclaredActionsInsidePlanNamespace() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        Action action =
+                new Action(
+                        "python-action",
+                        new PythonFunction("app.agent", "handle"),
+                        List.of(InputEvent.EVENT_TYPE));
+        AgentPlan plan =
+                new AgentPlan(
+                        Map.of(action.getName(), action),
+                        Map.of(InputEvent.EVENT_TYPE, List.of(action)));
+        PythonActionExecutor executor = createExecutor(interpreter, plan);
+
+        executor.open();
+
+        verify(interpreter)
+                .invokeMethod(
+                        "__fa_function_module",
+                        "resolve_python_function",
+                        "app.agent",
+                        "handle",
+                        "__fa_job_operator_v2");
+    }
+
     private static PythonActionExecutor createExecutor(PythonInterpreter interpreter)
             throws Exception {
+        return createExecutor(interpreter, new AgentPlan(Map.of(), Map.of()));
+    }
+
+    private static PythonActionExecutor createExecutor(
+            PythonInterpreter interpreter, AgentPlan agentPlan) throws Exception {
         return new PythonActionExecutor(
                 interpreter,
-                new AgentPlan(Map.of(), Map.of()),
+                agentPlan,
                 mock(JavaResourceAdapter.class),
                 mock(PythonRunnerContextImpl.class),
-                "job-1");
+                "job-1",
+                "__fa_job_operator_v2");
     }
 }

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonActionExecutorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.agents.runtime.python.utils;
+
+import org.apache.flink.agents.plan.AgentPlan;
+import org.apache.flink.agents.runtime.python.context.PythonRunnerContextImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import pemja.core.PythonInterpreter;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PythonActionExecutorTest {
+
+    @Test
+    void frameworkCallsUseBoundModuleMethods() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        Object output = new Object();
+        when(interpreter.invokeMethod(
+                        "__fa_java_utils_module", "get_output_from_output_event", "event-json"))
+                .thenReturn(output);
+        PythonActionExecutor executor = createExecutor(interpreter);
+
+        assertThat(executor.getOutputFromOutputEvent("event-json")).isSameAs(output);
+        verify(interpreter)
+                .invokeMethod(
+                        "__fa_java_utils_module", "get_output_from_output_event", "event-json");
+    }
+
+    @Test
+    void openBindsReservedAndLegacyGlobalsWithoutProcessAliases() throws Exception {
+        PythonInterpreter interpreter = mock(PythonInterpreter.class);
+        PythonActionExecutor executor = createExecutor(interpreter);
+
+        executor.open();
+
+        ArgumentCaptor<String> imports = ArgumentCaptor.forClass(String.class);
+        verify(interpreter).exec(imports.capture());
+        assertThat(imports.getValue())
+                .contains(
+                        "from flink_agents.plan import function as __fa_function_module",
+                        "function = __fa_function_module")
+                .doesNotContain("sys.modules[");
+    }
+
+    private static PythonActionExecutor createExecutor(PythonInterpreter interpreter)
+            throws Exception {
+        return new PythonActionExecutor(
+                interpreter,
+                new AgentPlan(Map.of(), Map.of()),
+                mock(JavaResourceAdapter.class),
+                mock(PythonRunnerContextImpl.class),
+                "job-1");
+    }
+}

--- a/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImplTest.java
+++ b/runtime/src/test/java/org/apache/flink/agents/runtime/python/utils/PythonResourceAdapterImplTest.java
@@ -82,6 +82,47 @@ public class PythonResourceAdapterImplTest {
     }
 
     @Test
+    void planNamespaceIsForwardedForUserResourcesAndTools() {
+        PythonResourceAdapterImpl namespacedAdapter =
+                new PythonResourceAdapterImpl(
+                        resourceContext, mockInterpreter, null, "__fa_job_operator_v2");
+        Map<String, Object> kwargs = new HashMap<>();
+        when(mockInterpreter.invoke(
+                        PythonResourceAdapterImpl.GET_PYTHON_TOOL_METADATA,
+                        "app.tools",
+                        "lookup",
+                        java.util.List.of(),
+                        "__fa_job_operator_v2"))
+                .thenReturn(Map.of("name", "lookup"));
+
+        namespacedAdapter.initPythonResource("app.resources", "Resource", kwargs);
+        namespacedAdapter.getPythonToolMetadata("app.tools", "lookup");
+        namespacedAdapter.invokePythonTool("app.tools", "lookup", kwargs);
+
+        verify(mockInterpreter)
+                .invoke(
+                        PythonResourceAdapterImpl.CREATE_RESOURCE,
+                        "app.resources",
+                        "Resource",
+                        kwargs,
+                        "__fa_job_operator_v2");
+        verify(mockInterpreter)
+                .invoke(
+                        PythonResourceAdapterImpl.GET_PYTHON_TOOL_METADATA,
+                        "app.tools",
+                        "lookup",
+                        java.util.List.of(),
+                        "__fa_job_operator_v2");
+        verify(mockInterpreter)
+                .invoke(
+                        PythonResourceAdapterImpl.INVOKE_PYTHON_TOOL,
+                        "app.tools",
+                        "lookup",
+                        kwargs,
+                        "__fa_job_operator_v2");
+    }
+
+    @Test
     void testOpen() {
 
         pythonResourceAdapter.open();

--- a/tools/ut.sh
+++ b/tools/ut.sh
@@ -145,7 +145,7 @@ java_tests() {
         done
         dist_modules="${dist_modules#,}"
 
-        mvn --batch-mode --no-transfer-progress install -pl "$dist_modules" -DskipTests ${SPOTLESS_FLAG}
+        mvn --batch-mode --no-transfer-progress clean install -pl "$dist_modules" -am -DskipTests ${SPOTLESS_FLAG}
         install_code=$?
         if [ $install_code -ne 0 ]; then
             echo "Failed to install dist packages" >&2
@@ -155,7 +155,7 @@ java_tests() {
         local all_passed=true
         for version in "${flink_versions[@]}"; do
             echo "Running E2E tests for Flink ${version}..."
-            mvn --batch-mode --no-transfer-progress test -pl 'e2e-test/flink-agents-end-to-end-tests-integration' -Pflink-${version} -Dsurefire.rerunFailingTestsCount=2 ${SPOTLESS_FLAG}
+            mvn --batch-mode --no-transfer-progress clean test -pl 'e2e-test/flink-agents-end-to-end-tests-integration' -Pflink-${version} -Dsurefire.rerunFailingTestsCount=2 ${SPOTLESS_FLAG}
 
             if [ $? -ne 0 ]; then
                 echo "E2E tests failed for Flink ${version}" >&2


### PR DESCRIPTION
### Purpose of change

<!-- What is the purpose of this change? -->

This change allows a checkpoint-enabled Flink Agents job to replace a complete
`AgentPlan` in place without restarting the job.

### Tests
Key coverage includes:

- `PlanUpdateCoordinatorTest.java`

  Eighteen tests cover:

  - qualification of a candidate by checkpoint K;
  - prevention of borrowing a checkpoint completed before submission;
  - delivery confirmation fencing before K+1;
  - activation state written into the K+1 recovery image;
  - retry after an aborted lower-bound checkpoint;
  - dropping volatile candidates on global recovery;
  - generation fencing for delayed delivery callbacks;
  - global failover on delivery, attempt, reset, preparation, activation, and
    activation-checkpoint failures.

- `DynamicPlanSwitchOperatorTest.java`

  Twenty-three tests cover:

  - pending-before-barrier and drain-before-switch behavior;
  - restoration directly into the plan snapshotted by K+1;
  - stale and duplicate event handling;
  - bootstrap configuration pinning;
  - preservation of the coordinator-minted `planId` through effective-plan
    snapshot and restore;
  - isolation of different candidates that reuse the same `planVersion`;
  - reuse of ActionState when the same `planId` is resubmitted;
  - Java artifact digest validation, tamper detection, classloading, activation,
    and recovery;
  - Python artifact validation, versioned dependency graphs, activation
    failures, and recovery;
  - propagation of the active Java classloader through the Python bridge.

- ActionState tests

  Utility, in-memory, Kafka, and Fluss tests verify `planId`-scoped keys,
  cross-plan isolation, divergence detection, and cleanup without deleting
  another plan's state.

- `python/flink_agents/plan/tests/test_module_namespace.py`

  Ten test functions, expanding to seventeen parameterized cases, cover:

  - absolute, relative, alias, and package re-export imports;
  - action, tool, and resource changes;
  - transitive dependency changes;
  - added and removed modules;
  - built-in tool dispatch for sync and async functions;
  - suspended old references while a new version is loaded;
  - cleanup only after the final namespace lease is released.

- `JavaAgentPlanClientE2ETest.java`

  Starts a real checkpoint-enabled MiniCluster with a serial two-Agent topology
  under the default chaining configuration. It overlaps updates to the two
  independently named Agents and verifies that:

  - both Agents initially execute V1;
  - accepting an update does not make it immediately visible;
  - checkpoint K still executes the previous plan;
  - each Agent switches only at its own K+1 boundary;
  - coordinator routing does not update the other named Agent;
  - the job remains running after both updates.

- `python/flink_agents/e2e_tests/e2e_tests_integration/agent_plan_client_test.py`

  Starts a real remote PyFlink job and MiniCluster, submits V2 through the Python
  client, and verifies:

  `v1:1 -> v1:2 -> v1:3 -> v2:4`

  These outputs correspond to the state before submission, after candidate
  acceptance, after checkpoint K, and after checkpoint K+1.

### API

<!-- Does this change touch any public APIs? -->

Yes.

Java APIs:

- `AgentBuilder.apply(String agentName, Agent agent)`
- `AgentPlanClient(String restAddress, int restPort)`
- `AgentPlanClient.updateAgentPlan(...)`
- `AgentPlanClient.UpdateResult`
- `ActionStateStore.setActivePlanId(String planId)`

Python APIs:

- `AgentBuilder.apply(agent, name=None)`
- `AgentPlanClient.create(rest_address, rest_port)`
- `AgentPlanClient.update_agent_plan(...)`
- `AgentPlanClient.update_agent(...)`
- `PlanUpdateResult`

Plan-scoped artifact configuration:

- `dynamic-plan.java-artifact.path`
- `dynamic-plan.java-artifact.sha256`
- `dynamic-plan.python-artifact.path`
- `dynamic-plan.python-artifact.sha256`